### PR TITLE
[fix] Update aws-oidc Makefile for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ clean: ## clean the repo
 
 setup: # setup development dependencies
 	export GO111MODULE=on
+	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
 	curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- v0.9.14
 	curl -sfL https://raw.githubusercontent.com/chanzuckerberg/bff/master/download.sh | sh


### PR DESCRIPTION
The release target in aws-oidc's Makefile relies on goreleaser,
therefore we should install it as part of `make setup`.