### PR TITLE
[fix] Overwrite old aws config sections

### DIFF
--- a/pkg/aws_config_client/completer.go
+++ b/pkg/aws_config_client/completer.go
@@ -131,6 +131,8 @@ func (c *completer) writeAWSProfile(out *ini.File, region string, profile *AWSNa
 		profile.AWSProfile.RoleARN,
 	)
 
+	// First delete sections with this name so old configuration doesn't persist
+	out.DeleteSection(profileSection)
 	section, err := out.NewSection(profileSection)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to create %s section in AWS Config", profileSection)

--- a/pkg/aws_config_client/completer_test.go
+++ b/pkg/aws_config_client/completer_test.go
@@ -32,6 +32,12 @@ region             = us-west-2
 `
 
 	out := ini.Empty()
+
+	// we add a junk section and make sure it disappears in the output
+	junkSection, err := out.NewSection("profile test1")
+	r.NoError(err)
+	junkSection.Key("role_arn").SetValue("this should disappear")
+
 	prompt := &MockPrompt{
 
 		selectResponse: []int{
@@ -48,7 +54,7 @@ region             = us-west-2
 
 	c := NewCompleter(prompt, generateDummyData())
 
-	err := c.Loop(out)
+	err = c.Loop(out)
 	r.NoError(err)
 
 	generatedConfig := bytes.NewBuffer(nil)


### PR DESCRIPTION
To avoid having competing fields such as `source_profile` or `role_arn` from before the migration.