### PR TITLE
[feature] Give us the ability to skip roles

### DIFF
--- a/docs/serve-config.md
+++ b/docs/serve-config.md
@@ -24,6 +24,9 @@ You can create create those values using [this tutorial](https://developer.okta.
 
 
 ###  AWS Config Generation:
-AWS_READER_ROLE_NAME: role name that can run AWS List Roles in any account in your AWS Organization
+AWS_READER_ROLE_NAME: role name that can run AWS List Roles in within each account in your AWS Organization
 
 AWS_MASTER_ROLE_ARNS: a list of role ARNs that can list accounts in your AWS Organizatio
+
+### Skipping roles
+You can tag AWS Roles with "aws-oidc/skip-role" if you don't want serve-config to return this role to users.

--- a/docs/serve-config.md
+++ b/docs/serve-config.md
@@ -29,4 +29,4 @@ AWS_READER_ROLE_NAME: role name that can run AWS List Roles in within each accou
 AWS_MASTER_ROLE_ARNS: a list of role ARNs that can list accounts in your AWS Organizatio
 
 ### Skipping roles
-You can tag AWS Roles with "aws-oidc/skip-role" if you don't want serve-config to return this role to users.
+You can tag AWS Roles with `aws-oidc/skip-role` if you want `serve-config` to skip this role.

--- a/pkg/aws_config_server/constants.go
+++ b/pkg/aws_config_server/constants.go
@@ -1,0 +1,9 @@
+package aws_config_server
+
+const (
+	// aws iam role tag that will make us skip over this role
+	skipRolesTagKey = "aws-oidc/skip-role"
+
+	// helps distinguish AWS "AccessDenied" errors
+	ignoreAWSError = "AccessDenied"
+)

--- a/pkg/aws_config_server/list_roles_test.go
+++ b/pkg/aws_config_server/list_roles_test.go
@@ -42,7 +42,9 @@ func TestListRoles(t *testing.T) {
 
 	iamOutput, err := listRoles(ctx, mock)
 	r.NoError(err)
+	r.Len(testRoles1, 2) // we skipped over a role
 	r.Len(iamOutput, 1)
+	r.Equal(*iamOutput[0].RoleName, *testRoles1[0].RoleName)
 }
 
 func TestClientRoleMapFromProfile(t *testing.T) {

--- a/pkg/aws_config_server/shared_variables_test.go
+++ b/pkg/aws_config_server/shared_variables_test.go
@@ -217,6 +217,13 @@ var testRoles1 = []*iam.Role{
 		Arn:      aws.String(BareRoleARN("roleARN0").String()),
 		RoleName: aws.String("testRoles1"),
 	},
+	{
+		Arn:      aws.String(BareRoleARN("skip-me").String()),
+		RoleName: aws.String("skip-me"),
+		Tags: []*iam.Tag{
+			{Key: aws.String(skipRolesTagKey)},
+		},
+	},
 }
 var testRoles2 = []*iam.Role{
 	{


### PR DESCRIPTION
We have some roles that are not meant to be consumed directly. Presenting these "hidden roles" to users makes it confusing for "non-experts". This tagging mechanism allows us to skip roles that are not meant for aws-oidc consumption.