### PR TITLE
[breaking] Refactor env,exec to use --profile or AWS_PROFILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ $ aws-oidc creds-process --issuer-url=<issuer url> --client-id=<client ID> --aws
 ```
 
 ### exec
-Executes a command with AWS credentials loaded in the environment
+Executes a command with AWS credentials loaded in the environment. Requires your `~/.aws/config` to be managed through `aws-oidc configure`.
 ``` bash
-$ aws-oidc exec --issuer-url=<issuer url> --client-id=<client ID> --aws-role-arn=<AWS role you want credentials for>   -- aws sts get-caller-identity
+$ aws-oidc exec --profile <your profile> -- aws sts get-caller-identity
 {
 	“UserId”: <...>
 	“Account”: <Account from that role-arn flag>
@@ -49,7 +49,7 @@ Deploys a service that displays an AWS Config file for any authorized visitor (s
 Will query your aws config service (serve-config command) to help populate your `~/.aws/config`. It will guide you through the process of setting this up.
 
 ### env
-Env is primarily here to assist when running docker locally. It requires your `~/.aws/config` to be properly configured. You can run the following to test it out:
+Env is primarily here to assist when running docker locally. It requires your `~/.aws/config` to be configured through `aws-oidc configure`. You can run the following to test it out:
 
 ```
 docker run -it --env-file <(go run main.go env --profile <your aws profile>) amazon/aws-cli sts get-caller-identity

--- a/cmd/creds-process.go
+++ b/cmd/creds-process.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/chanzuckerberg/aws-oidc/pkg/aws_config_client"
 	"github.com/chanzuckerberg/aws-oidc/pkg/getter"
 	oidc "github.com/chanzuckerberg/go-misc/oidc_cli"
 	"github.com/pkg/errors"
@@ -48,9 +49,11 @@ func credProcessRun(cmd *cobra.Command, args []string) error {
 
 	assumeRoleOutput, err := assumeRole(
 		ctx,
-		clientID,
-		issuerURL,
-		roleARN,
+		&aws_config_client.AWSOIDCConfiguration{
+			ClientID:  clientID,
+			IssuerURL: issuerURL,
+			RoleARN:   roleARN,
+		},
 	)
 	if err != nil {
 		return err
@@ -75,14 +78,18 @@ func credProcessRun(cmd *cobra.Command, args []string) error {
 
 func assumeRole(
 	ctx context.Context,
-	clientID string,
-	issuerURL string,
-	roleARN string,
+	awsOIDCConfig *aws_config_client.AWSOIDCConfiguration,
 ) (*sts.AssumeRoleWithWebIdentityOutput, error) {
-	token, err := oidc.GetToken(ctx, clientID, issuerURL)
+	token, err := oidc.GetToken(
+		ctx,
+		awsOIDCConfig.ClientID,
+		awsOIDCConfig.IssuerURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to obtain OIDC token")
 	}
-	assumeRoleOutput, err := getter.GetAWSAssumeIdentity(ctx, token, roleARN)
+	assumeRoleOutput, err := getter.GetAWSAssumeIdentity(
+		ctx,
+		token,
+		awsOIDCConfig.RoleARN)
 	return assumeRoleOutput, errors.Wrap(err, "unable to assume role")
 }

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -3,27 +3,20 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/chanzuckerberg/aws-oidc/pkg/aws_config_client"
-	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/ini.v1"
 )
 
-var profileName string
-
-const (
-	clientIDRegex  = "--client-id=(?P<ClientID>\\S+)"
-	issuerURLRegex = "--issuer-url=(?P<IssuerURL>\\S+)"
-	roleARNRegex   = "--aws-role-arn=(?P<RoleARN>\\S+)"
-)
+var flagProfileName string
 
 func init() {
-	envCmd.Flags().StringVar(&profileName, "profile", "", "AWS Profile to fetch credentials from.")
-	envCmd.MarkFlagRequired("profile") //nolint:errcheck
+	envCmd.Flags().StringVar(
+		&flagProfileName,
+		aws_config_client.FlagProfile,
+		"",
+		"AWS Profile to fetch credentials from.")
 
 	rootCmd.AddCommand(envCmd)
 }
@@ -39,76 +32,20 @@ var envCmd = &cobra.Command{
 
 func envRun(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-
-	// load and parse AWS config file
-	awsConfigPath, err := homedir.Expand("~/.aws/config")
+	awsOIDCConfig, err := aws_config_client.FetchParamsFromAWSConfig(
+		cmd,
+		aws_config_client.DefaultAWSConfigPath)
 	if err != nil {
-		return errors.Wrap(err, "Could not parse aws config file path")
-	}
-	ini, err := ini.Load(awsConfigPath)
-	if err != nil {
-		return errors.Wrap(err, "could not open aws config")
+		return err
 	}
 
-	profileSectionName := fmt.Sprintf("profile %s", profileName)
-	section, err := ini.GetSection(profileSectionName)
+	assumeRoleOutput, err := assumeRole(ctx, awsOIDCConfig)
 	if err != nil {
-		return errors.Wrapf(
-			err,
-			"could not fetch %s from aws config",
-			profileSectionName)
+		return err
 	}
-
-	credProcess, err := section.GetKey(aws_config_client.AWSConfigSectionCredentialProcess)
-	if err != nil {
-		return errors.Wrapf(
-			err,
-			"%s not defined for profile %s",
-			aws_config_client.AWSConfigSectionCredentialProcess,
-			profileSectionName,
-		)
-	}
-
-	credProcessCmd := credProcess.String()
-
-	clientID, err = extractCredProcess(credProcessCmd, clientIDRegex)
-	if err != nil {
-		return errors.Wrapf(err, "could not extract --client-id from (%s)", credProcessCmd)
-	}
-	issuerURL, err = extractCredProcess(credProcessCmd, issuerURLRegex)
-	if err != nil {
-		return errors.Wrapf(err, "could not extract --issuer-url from (%s)", credProcessCmd)
-	}
-	roleARN, err = extractCredProcess(credProcessCmd, roleARNRegex)
-	if err != nil {
-		return errors.Wrapf(err, "could not extract --aws-role-arn from (%s)", credProcessCmd)
-	}
-
-	assumeRoleOutput, err := assumeRole(
-		ctx,
-		clientID,
-		issuerURL,
-		roleARN,
-	)
-	if err != nil {
-		return nil
-	}
-
-	envVars := getAWSEnvVars(assumeRoleOutput)
 
 	// output in the appropriate format for docker
+	envVars := getAWSEnvVars(assumeRoleOutput)
 	fmt.Fprintln(os.Stdout, strings.Join(envVars, "\n"))
 	return nil
-}
-
-// HACK(el): This is not the best, but decided to do this to:
-//           - Not add extraneous fields to user's AWS config files
-//           - Not have to maintain a parallel config file
-func extractCredProcess(command string, regex string) (string, error) {
-	r := regexp.MustCompile(regex)
-	submatches := r.FindStringSubmatch(command)
-	if len(submatches) != 2 {
-		return "", errors.Errorf("did not find match")
-	}
-	return submatches[1], nil
 }

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveProfile(t *testing.T) {
+	r := require.New(t)
+
+	// https://golang.org/src/os/env_test.go
+	defer func(origEnv []string) {
+		for _, pair := range origEnv {
+			// Environment variables on Windows can begin with =
+			// https://blogs.msdn.com/b/oldnewthing/archive/2010/05/06/10008132.aspx
+			i := strings.Index(pair[1:], "=") + 1
+			if err := os.Setenv(pair[:i], pair[i+1:]); err != nil {
+				t.Errorf("Setenv(%q, %q) failed during reset: %v", pair[:i], pair[i+1:], err)
+			}
+		}
+	}(os.Environ())
+	r.NoError(os.Unsetenv(envAWSProfile))
+
+	// default
+	r.Equal(defaultAWSProfile, resolveProfile(nil))
+
+	// from env
+	expectedProfile := "asdfasdfalkwq;e"
+	os.Setenv(envAWSProfile, expectedProfile)
+	r.Equal(expectedProfile, resolveProfile(nil))
+
+	// flag
+	expectedProfile = "flag-profile"
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(
+		&flagProfileName,
+		flagProfile,
+		"",
+		"AWS Profile to fetch credentials from.")
+
+	r.NoError(cmd.Flags().Set(
+		flagProfile,
+		expectedProfile))
+	r.Equal(expectedProfile, resolveProfile(cmd))
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/chanzuckerberg/aws-oidc/pkg/aws_config_client"
 	"github.com/chanzuckerberg/aws-oidc/pkg/getter"
 	oidc "github.com/chanzuckerberg/go-misc/oidc_cli"
 	"github.com/pkg/errors"
@@ -12,13 +13,13 @@ import (
 )
 
 func init() {
+	execCmd.Flags().StringVar(
+		&flagProfileName,
+		aws_config_client.FlagProfile,
+		"",
+		"AWS Profile to fetch credentials from. Can set AWS_PROFILE instead.")
+
 	rootCmd.AddCommand(execCmd)
-	execCmd.Flags().StringVar(&clientID, "client-id", "", "CLIENT_ID generated from the OIDC application")
-	execCmd.Flags().StringVar(&issuerURL, "issuer-url", "", "The URL that hosts the OIDC identity provider")
-	execCmd.Flags().StringVar(&roleARN, "aws-role-arn", "", "ARN value of role to assume")
-	execCmd.MarkFlagRequired("client-id")    // nolint:errcheck
-	execCmd.MarkFlagRequired("issuer-url")   // nolint:errcheck
-	execCmd.MarkFlagRequired("aws-role-arn") // nolint:errcheck
 }
 
 var execCmd = &cobra.Command{
@@ -44,12 +45,19 @@ func execRun(cmd *cobra.Command, args []string) error {
 	command := args[dashIndex]
 	commandArgs := args[dashIndex+1:]
 
-	token, err := oidc.GetToken(ctx, clientID, issuerURL)
+	awsOIDCConfig, err := aws_config_client.FetchParamsFromAWSConfig(
+		cmd,
+		aws_config_client.DefaultAWSConfigPath)
+	if err != nil {
+		return err
+	}
+
+	token, err := oidc.GetToken(ctx, awsOIDCConfig.ClientID, awsOIDCConfig.IssuerURL)
 	if err != nil {
 		return errors.Wrap(err, "Unable to obtain token from clientID and issuerURL")
 	}
 
-	assumeRoleOutput, err := getter.GetAWSAssumeIdentity(ctx, token, roleARN)
+	assumeRoleOutput, err := getter.GetAWSAssumeIdentity(ctx, token, awsOIDCConfig.RoleARN)
 	if err != nil {
 		return errors.Wrap(err, "Unable to extract right token output from AWS Assume Web identity")
 	}

--- a/pkg/aws_config_client/parse_aws_config.go
+++ b/pkg/aws_config_client/parse_aws_config.go
@@ -1,0 +1,120 @@
+package aws_config_client
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/ini.v1"
+)
+
+const (
+	clientIDRegex  = "--client-id=(?P<ClientID>\\S+)"
+	issuerURLRegex = "--issuer-url=(?P<IssuerURL>\\S+)"
+	roleARNRegex   = "--aws-role-arn=(?P<RoleARN>\\S+)"
+
+	FlagProfile = "profile"
+
+	defaultAWSProfile    = "default"
+	DefaultAWSConfigPath = "~/.aws/config"
+
+	envAWSProfile = "AWS_PROFILE"
+)
+
+type AWSOIDCConfiguration struct {
+	ClientID  string
+	IssuerURL string
+	RoleARN   string
+}
+
+// HACK(el): This is not the best, but decided to do this to:
+//           - Not add extraneous fields to user's AWS config files
+//           - Not have to maintain a parallel config file
+func extractCredProcess(command string, regex string) (string, error) {
+	r := regexp.MustCompile(regex)
+	submatches := r.FindStringSubmatch(command)
+	if len(submatches) != 2 {
+		return "", errors.Errorf("did not find match")
+	}
+	return submatches[1], nil
+}
+
+func resolveProfile(cmd *cobra.Command) (string, error) {
+	// the default profile
+	profile := defaultAWSProfile
+
+	// env has precedence over default
+	envProfile, present := os.LookupEnv(envAWSProfile)
+	if present {
+		profile = envProfile
+	}
+
+	// flag has precedence over env and default
+	if cmd != nil && cmd.Flags().Changed(FlagProfile) {
+		flagProfileValue, err := cmd.Flags().GetString(FlagProfile)
+		if err != nil {
+			return "", errors.Wrapf(err, "could not read command line flag %s", FlagProfile)
+		}
+		profile = flagProfileValue
+	}
+
+	return profile, nil
+}
+
+func FetchParamsFromAWSConfig(cmd *cobra.Command, awsConfigPath string) (*AWSOIDCConfiguration, error) {
+	// load and parse AWS config file
+	awsConfigPath, err := homedir.Expand(awsConfigPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not parse aws config file path")
+	}
+	ini, err := ini.Load(awsConfigPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not open aws config")
+	}
+
+	// grab the section corresponding to our profile
+	profileName, err := resolveProfile(cmd)
+	if err != nil {
+		return nil, err
+	}
+	profileSectionName := fmt.Sprintf("profile %s", profileName)
+	section, err := ini.GetSection(profileSectionName)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"could not fetch %s section from aws config",
+			profileSectionName)
+	}
+
+	credProcess, err := section.GetKey(AWSConfigSectionCredentialProcess)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"%s not defined for profile %s",
+			AWSConfigSectionCredentialProcess,
+			profileSectionName,
+		)
+	}
+
+	credProcessCmd := credProcess.String()
+	clientID, err := extractCredProcess(credProcessCmd, clientIDRegex)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not extract --client-id from (%s)", credProcessCmd)
+	}
+	issuerURL, err := extractCredProcess(credProcessCmd, issuerURLRegex)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not extract --issuer-url from (%s)", credProcessCmd)
+	}
+	roleARN, err := extractCredProcess(credProcessCmd, roleARNRegex)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not extract --aws-role-arn from (%s)", credProcessCmd)
+	}
+	return &AWSOIDCConfiguration{
+		ClientID:  clientID,
+		IssuerURL: issuerURL,
+		RoleARN:   roleARN,
+	}, nil
+}

--- a/pkg/aws_config_client/parse_aws_config_test.go
+++ b/pkg/aws_config_client/parse_aws_config_test.go
@@ -1,4 +1,4 @@
-package cmd
+package aws_config_client
 
 import (
 	"os"
@@ -26,24 +26,33 @@ func TestResolveProfile(t *testing.T) {
 	r.NoError(os.Unsetenv(envAWSProfile))
 
 	// default
-	r.Equal(defaultAWSProfile, resolveProfile(nil))
+	prof, err := resolveProfile(nil)
+	r.NoError(err)
+	r.Equal(defaultAWSProfile, prof)
 
 	// from env
 	expectedProfile := "asdfasdfalkwq;e"
 	os.Setenv(envAWSProfile, expectedProfile)
-	r.Equal(expectedProfile, resolveProfile(nil))
+	prof, err = resolveProfile(nil)
+	r.NoError(err)
+	r.Equal(expectedProfile, prof)
 
 	// flag
+	var flagVal string
+
 	expectedProfile = "flag-profile"
 	cmd := &cobra.Command{}
 	cmd.Flags().StringVar(
-		&flagProfileName,
-		flagProfile,
+		&flagVal,
+		FlagProfile,
 		"",
 		"AWS Profile to fetch credentials from.")
 
 	r.NoError(cmd.Flags().Set(
-		flagProfile,
+		FlagProfile,
 		expectedProfile))
-	r.Equal(expectedProfile, resolveProfile(cmd))
+
+	prof, err = resolveProfile(cmd)
+	r.NoError(err)
+	r.Equal(expectedProfile, prof)
 }


### PR DESCRIPTION
- Instead of having to do `aws-oidc exec --client-id <asdfasdf> --issuer-url <asdfasdfa> --aws-role-arn <asdfasdf> -- cmd` we can now do `aws-oidc exec --profile <my profile> -- cmd`. Trade-off is we require that `<my profile>` be managed through `aws-oidc configure` so we can parse the necessary info.

- Profile names get calcualted in precedence order from:
    1. use the `--profile` flag if provided
    1. otherwise use the AWS_PROFILE env variable if provided
    1. otherwise use the `default` profile

This should follow AWS SDK conventions.