### PR TITLE
[fix] Use the account alias when present everywhere

### DIFF
--- a/pkg/aws_config_client/completer.go
+++ b/pkg/aws_config_client/completer.go
@@ -39,7 +39,7 @@ func (c *completer) getAccountOptions(accounts []server.AWSAccount) []string {
 	for _, account := range accounts {
 		accountOptions = append(
 			accountOptions,
-			fmt.Sprintf("%s (%s)", account.Name, account.ID))
+			fmt.Sprintf("%s (%s)", account.GetAliasOrName(), account.ID))
 	}
 	return accountOptions
 }
@@ -69,11 +69,7 @@ func (c *completer) awsProfileNameValidator(input interface{}) error {
 
 func (c *completer) calculateDefaultProfileName(account server.AWSAccount) string {
 	invalid := regexp.MustCompile("[^a-zA-Z0-9_-]")
-	accountName := account.Alias
-	if accountName == "" {
-		accountName = account.Name
-	}
-	replaced := invalid.ReplaceAllString(accountName, "-")
+	replaced := invalid.ReplaceAllString(account.GetAliasOrName(), "-")
 	return strings.ToLower(replaced)
 }
 

--- a/pkg/aws_config_server/types.go
+++ b/pkg/aws_config_server/types.go
@@ -79,3 +79,10 @@ type AWSAccount struct {
 	Name  string `json:"name,omitempty"`
 	Alias string `json:"alias,omitempty"`
 }
+
+func (a *AWSAccount) GetAliasOrName() string {
+	if a.Alias != "" {
+		return a.Alias
+	}
+	return a.Name
+}


### PR DESCRIPTION
We weren't using the account alias everywhere/consistently