### PR TITLE
[fix] "Atomically" write aws config file

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -68,16 +68,14 @@ var configureCmd = &cobra.Command{
 		// We allow users to print aws config directly to stdout if they want
 		// instead of us directly trying to modify their aws config
 		if printOnly {
-			return completer.Complete(originalConfig, &aws_config_client.AWSConfigSTDOUT{})
+			return completer.Complete(originalConfig, &aws_config_client.AWSConfigSTDOUTWriter{})
 		}
 
-		awsConfigWriter := &aws_config_client.AWSConfigFile{}
-		err = awsConfigWriter.Open(awsConfigPath)
+		awsConfigWriter := aws_config_client.NewAWSConfigFileWriter(awsConfigPath)
+		err = completer.Complete(originalConfig, awsConfigWriter)
 		if err != nil {
 			return err
 		}
-		defer awsConfigWriter.Close()
-
-		return completer.Complete(originalConfig, awsConfigWriter)
+		return awsConfigWriter.Finalize()
 	},
 }

--- a/pkg/aws_config_client/writers_test.go
+++ b/pkg/aws_config_client/writers_test.go
@@ -1,0 +1,40 @@
+package aws_config_client
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAWSConfigFileWriter(t *testing.T) {
+	r := require.New(t)
+
+	dir, err := ioutil.TempDir("", "")
+	r.NoError(err)
+	defer os.RemoveAll(dir) //cleanup
+
+	awsConfigPath := path.Join(dir, "config")
+
+	writer := NewAWSConfigFileWriter(awsConfigPath)
+
+	expectedData := make([]byte, 256)
+	_, err = rand.Read(expectedData)
+	r.NoError(err)
+
+	_, err = io.Copy(writer, bytes.NewBuffer(expectedData))
+	r.NoError(err)
+
+	err = writer.Finalize()
+	r.NoError(err)
+
+	readData, err := ioutil.ReadFile(awsConfigPath)
+	r.NoError(err)
+
+	r.Equal(expectedData, readData)
+}


### PR DESCRIPTION
Instead of writing directly to the ~/.aws/config file, we write to a temporary file and then move it to the ~/.aws/config location. This helps prevent some category of race conditions where we have concurrent access to ~/.aws/config