### PR TITLE
[fix] Get rid of the tty redirect hack

### DIFF
--- a/pkg/aws_config_client/completer.go
+++ b/pkg/aws_config_client/completer.go
@@ -219,7 +219,7 @@ func (c *completer) assembleAWSConfig(region string, profiles []*AWSNamedProfile
 		profileSection := fmt.Sprintf("profile %s", profile.Name)
 
 		credsProcessValue := fmt.Sprintf(
-			"sh -c 'aws-oidc creds-process --issuer-url=%s --client-id=%s --aws-role-arn=%s 2> /dev/tty'",
+			"aws-oidc creds-process --issuer-url=%s --client-id=%s --aws-role-arn=%s",
 			profile.AWSProfile.IssuerURL,
 			profile.AWSProfile.ClientID,
 			profile.AWSProfile.RoleARN,

--- a/pkg/aws_config_client/completer_test.go
+++ b/pkg/aws_config_client/completer_test.go
@@ -30,7 +30,7 @@ func TestRemoveOldProfile(t *testing.T) {
 
 	expected := `[profile test1]
 output             = json
-credential_process = sh -c 'aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test1RoleName 2> /dev/tty'
+credential_process = aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test1RoleName
 region             = test-region
 
 `
@@ -61,17 +61,17 @@ func TestSurveyProfiles(t *testing.T) {
 	// note how: "Account Name With Spaces" => "account-name-with-spaces"
 	expected := `[profile test1]
 output             = json
-credential_process = sh -c 'aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test1RoleName 2> /dev/tty'
+credential_process = aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test1RoleName
 region             = test-region
 
 [profile account-name-with-spaces]
 output             = json
-credential_process = sh -c 'aws-oidc creds-process --issuer-url=issuer-url --client-id=foo_client_id --aws-role-arn=test1RoleName 2> /dev/tty'
+credential_process = aws-oidc creds-process --issuer-url=issuer-url --client-id=foo_client_id --aws-role-arn=test1RoleName
 region             = test-region
 
 [profile my-second-new-profile]
 output             = json
-credential_process = sh -c 'aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test1RoleName 2> /dev/tty'
+credential_process = aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test1RoleName
 region             = test-region
 
 `
@@ -114,32 +114,32 @@ func TestSurveyRoles(t *testing.T) {
 
 	expected := `[profile account-name-with-spaces-test1RoleName]
 output             = json
-credential_process = sh -c 'aws-oidc creds-process --issuer-url=issuer-url --client-id=foo_client_id --aws-role-arn=test1RoleName 2> /dev/tty'
+credential_process = aws-oidc creds-process --issuer-url=issuer-url --client-id=foo_client_id --aws-role-arn=test1RoleName
 region             = test-region
 
 [profile account-name-with-spaces]
 output             = json
-credential_process = sh -c 'aws-oidc creds-process --issuer-url=issuer-url --client-id=foo_client_id --aws-role-arn=test1RoleName 2> /dev/tty'
+credential_process = aws-oidc creds-process --issuer-url=issuer-url --client-id=foo_client_id --aws-role-arn=test1RoleName
 region             = test-region
 
 [profile account-name-with-spaces-test2RoleName]
 output             = json
-credential_process = sh -c 'aws-oidc creds-process --issuer-url=issuer-url --client-id=foo_client_id --aws-role-arn=test2RoleName 2> /dev/tty'
+credential_process = aws-oidc creds-process --issuer-url=issuer-url --client-id=foo_client_id --aws-role-arn=test2RoleName
 region             = test-region
 
 [profile test1-test1RoleName]
 output             = json
-credential_process = sh -c 'aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test1RoleName 2> /dev/tty'
+credential_process = aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test1RoleName
 region             = test-region
 
 [profile test1]
 output             = json
-credential_process = sh -c 'aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test1RoleName 2> /dev/tty'
+credential_process = aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test1RoleName
 region             = test-region
 
 [profile test1-test2RoleName]
 output             = json
-credential_process = sh -c 'aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test2RoleName 2> /dev/tty'
+credential_process = aws-oidc creds-process --issuer-url=issuer-url --client-id=bar_client_id --aws-role-arn=test2RoleName
 region             = test-region
 
 `

--- a/pkg/aws_config_client/parse_aws_config.go
+++ b/pkg/aws_config_client/parse_aws_config.go
@@ -52,7 +52,7 @@ func cleanCredProcessCommand(command string) string {
 	before := regexp.MustCompile("^.*?['\"]")
 	// clean up after the last quote
 	after := regexp.MustCompile("['\"].*$")
-	// get rid of the tty if present
+	// get rid of the tty hack if present
 	tty := regexp.MustCompile("2> /dev/tty")
 
 	command = string(before.ReplaceAll([]byte(command), []byte("")))


### PR DESCRIPTION
We already ran into an issue with this tty redirect hack (ruby on rails not running with a tty). Getting rid of it.

Note: should still be backwards-compatible with configs that have the tty redirect present.