### PR TITLE
[fix] reduce unique errors coming out of our AccessDenied error logging

### DIFF
--- a/pkg/aws_config_server/list_roles.go
+++ b/pkg/aws_config_server/list_roles.go
@@ -249,7 +249,7 @@ func getAcctAlias(ctx context.Context, svc iamiface.IAMAPI) (*string, error) {
 	input := &iam.ListAccountAliasesInput{}
 	output, err := svc.ListAccountAliasesWithContext(ctx, input)
 	if processAWSErr(err) != nil {
-		return nil, errors.Wrap(err, "coudl not get account alias")
+		return nil, errors.Wrap(err, "could not get account alias")
 	}
 
 	// no alias
@@ -271,7 +271,7 @@ func processAWSErr(err error) error {
 		return err
 	}
 	if awsErr.Code() == errAWSAccessDenied {
-		logrus.WithError(err).Errorf("AWS error %s", awsErr)
+		logrus.Errorf("AWS error %s", awsErr.Message())
 		return nil // we skip the access denied errors, but notify on them
 	}
 

--- a/pkg/aws_config_server/list_roles.go
+++ b/pkg/aws_config_server/list_roles.go
@@ -271,7 +271,7 @@ func processAWSErr(err error) error {
 		return err
 	}
 	if awsErr.Code() == errAWSAccessDenied {
-		logrus.Errorf("AWS error %s", awsErr.Message())
+		logrus.Errorf("AWS error: %s", awsErr.Message())
 		return nil // we skip the access denied errors, but notify on them
 	}
 

--- a/pkg/aws_config_server/list_roles_test.go
+++ b/pkg/aws_config_server/list_roles_test.go
@@ -19,14 +19,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type test struct {
+	name     string
+	in       error
+	expected error
+}
+
 func TestProcessAWSError(t *testing.T) {
 	r := require.New(t)
-
-	type test struct {
-		name     string
-		in       error
-		expected error
-	}
 
 	tests := []test{
 		{
@@ -54,6 +54,29 @@ func TestProcessAWSError(t *testing.T) {
 		fmt.Println(test.name)
 		r.Equal(test.expected, processAWSErr(test.in))
 	}
+}
+
+// aku: We're verifying the lines inside the processAWSError work as expected
+// We want to make sure two identical AccessDenied Errors return the same exact error
+// (we want to keep the logrus lines there, return nil if needed)
+// Even if the requestID field might be different
+func TestDuplicateAWSError(t *testing.T) {
+	r := require.New(t)
+
+	testErrors := []awserr.Error{
+		awserr.New(errAWSAccessDenied, "bla", nil),
+		awserr.New(errAWSAccessDenied, "bla", nil),
+	}
+
+	processedErrors := []error{}
+	for _, awsErr := range testErrors {
+		if awsErr.Code() == errAWSAccessDenied {
+			currentError := errors.Errorf("AWS error: %s", awsErr.Message())
+			processedErrors = append(processedErrors, currentError)
+		}
+	}
+	r.Len(processedErrors, 2)
+	r.Equal(processedErrors[0], processedErrors[1])
 }
 
 func TestGetAcctAlias(t *testing.T) {

--- a/pkg/aws_config_server/list_roles_test.go
+++ b/pkg/aws_config_server/list_roles_test.go
@@ -19,14 +19,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type test struct {
-	name     string
-	in       error
-	expected error
-}
-
 func TestProcessAWSError(t *testing.T) {
 	r := require.New(t)
+
+	type test struct {
+		name     string
+		in       error
+		expected error
+	}
 
 	tests := []test{
 		{


### PR DESCRIPTION
The `request-id` field prompted a flood of unique errors in our error reporting system, so I got rid of that unique identifier. 