### PR TITLE
[feature] add skip-accounts flag to serve-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ aws-oidc exec --profile <your profile> -- aws sts get-caller-identity
 }
 ```
 ### serve-config
-Deploys a service that displays an AWS Config file for any authorized visitor (see [Deployment Requirements](#deployment-requirements))
+Deploys a service that displays an AWS Config file for any authorized visitor.
 
 ### configure
 Will query your aws config service (serve-config command) to help populate your `~/.aws/config`. It will guide you through the process of setting this up.

--- a/cmd/serve-config.go
+++ b/cmd/serve-config.go
@@ -40,7 +40,7 @@ var skipAccountList []string
 
 func init() {
 	rootCmd.AddCommand(serveConfigCmd)
-	serveConfigCmd.Flags().IntVar(&webServerPort, "web-server-port", 8080, "port to host the aws config website")
+	serveConfigCmd.Flags().IntVar(&webServerPort, "web-server-port", 8080, "Port to host the aws config website")
 	serveConfigCmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of parallel goroutines for account processing")
 	serveConfigCmd.Flags().IntVar(&awsSessionRetries, "aws-retries", 5, "Number of times an AWS svc retries an operation")
 	serveConfigCmd.Flags().StringSliceVar(&skipAccountList, "skip-accts", []string{}, "List of accounts that skip serve-config processing")

--- a/cmd/serve-config.go
+++ b/cmd/serve-config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/honeycombio/beeline-go"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +42,7 @@ func init() {
 	serveConfigCmd.Flags().IntVar(&webServerPort, "web-server-port", 8080, "Port to host the aws config website")
 	serveConfigCmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of parallel goroutines for account processing")
 	serveConfigCmd.Flags().IntVar(&awsSessionRetries, "aws-retries", 5, "Number of times an AWS svc retries an operation")
-	serveConfigCmd.Flags().StringSliceVar(&skipAccountList, "skip-accts", []string{}, "List of accounts that skip serve-config processing")
+	serveConfigCmd.Flags().StringSliceVar(&skipAccountList, "skip-accts", []string{}, "List of account numbers that skip serve-config processing")
 }
 
 var serveConfigCmd = &cobra.Command{
@@ -141,11 +140,7 @@ func serveConfigRun(cmd *cobra.Command, args []string) error {
 		SkipAccounts:  sets.StringSet{},
 	}
 
-	for _, skipAcct := range skipAccountList {
-		logrus.Debug(skipAcct)
-		configGenerationParams.SkipAccounts.Add(skipAcct)
-	}
-	logrus.Debugf("skipAccts: %v\n", configGenerationParams.SkipAccounts)
+	configGenerationParams.SkipAccounts.Add(skipAccountList...)
 
 	getClientIDToProfiles, err := webserver.NewCachedGetClientIDToProfiles(
 		ctx,

--- a/cmd/serve-config.go
+++ b/cmd/serve-config.go
@@ -11,10 +11,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	webserver "github.com/chanzuckerberg/aws-oidc/pkg/aws_config_server"
 	CZIOkta "github.com/chanzuckerberg/aws-oidc/pkg/okta"
+	"github.com/chanzuckerberg/go-misc/sets"
 	"github.com/coreos/go-oidc"
 	"github.com/honeycombio/beeline-go"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -34,12 +36,14 @@ type AWSRoleEnvironment struct {
 
 var concurrency int
 var awsSessionRetries int
+var skipAccountList []string
 
 func init() {
 	rootCmd.AddCommand(serveConfigCmd)
 	serveConfigCmd.Flags().IntVar(&webServerPort, "web-server-port", 8080, "port to host the aws config website")
 	serveConfigCmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of parallel goroutines for account processing")
 	serveConfigCmd.Flags().IntVar(&awsSessionRetries, "aws-retries", 5, "Number of times an AWS svc retries an operation")
+	serveConfigCmd.Flags().StringSliceVar(&skipAccountList, "skip-accts", []string{}, "List of accounts that skip serve-config processing")
 }
 
 var serveConfigCmd = &cobra.Command{
@@ -134,7 +138,14 @@ func serveConfigRun(cmd *cobra.Command, args []string) error {
 		AWSWorkerRole: awsEnv.READER_ROLE_NAME,
 		AWSOrgRoles:   awsEnv.ORG_ROLE_ARNS,
 		Concurrency:   concurrency,
+		SkipAccounts:  sets.StringSet{},
 	}
+
+	for _, skipAcct := range skipAccountList {
+		logrus.Debug(skipAcct)
+		configGenerationParams.SkipAccounts.Add(skipAcct)
+	}
+	logrus.Debugf("skipAccts: %v\n", configGenerationParams.SkipAccounts)
 
 	getClientIDToProfiles, err := webserver.NewCachedGetClientIDToProfiles(
 		ctx,

--- a/cmd/serve-config.go
+++ b/cmd/serve-config.go
@@ -42,7 +42,7 @@ func init() {
 	serveConfigCmd.Flags().IntVar(&webServerPort, "web-server-port", 8080, "Port to host the aws config website")
 	serveConfigCmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of parallel goroutines for account processing")
 	serveConfigCmd.Flags().IntVar(&awsSessionRetries, "aws-retries", 5, "Number of times an AWS svc retries an operation")
-	serveConfigCmd.Flags().StringSliceVar(&skipAccountList, "skip-accts", []string{}, "List of account numbers that skip serve-config processing")
+	serveConfigCmd.Flags().StringSliceVar(&skipAccountList, "skip-accts", []string{}, "List of AWS account IDs serve-config should ignore.")
 }
 
 var serveConfigCmd = &cobra.Command{

--- a/pkg/aws_config_server/cache.go
+++ b/pkg/aws_config_server/cache.go
@@ -86,7 +86,7 @@ func (c *CachedGetClientIDToProfiles) refresh(
 		orgAssumer,
 		configParams.AWSOrgRoles,
 		configParams.AWSWorkerRole,
-		configParams.SkipAccounts, // note to self: should be a string set
+		configParams.SkipAccounts,
 	)
 	if err != nil {
 		return err

--- a/pkg/aws_config_server/cache.go
+++ b/pkg/aws_config_server/cache.go
@@ -86,6 +86,7 @@ func (c *CachedGetClientIDToProfiles) refresh(
 		orgAssumer,
 		configParams.AWSOrgRoles,
 		configParams.AWSWorkerRole,
+		configParams.SkipAccounts, // note to self: should be a string set
 	)
 	if err != nil {
 		return err

--- a/pkg/aws_config_server/list_roles.go
+++ b/pkg/aws_config_server/list_roles.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/organizations/organizationsiface"
+	"github.com/chanzuckerberg/go-misc/sets"
 	"github.com/hashicorp/go-multierror"
 	"github.com/honeycombio/beeline-go"
 	"github.com/pkg/errors"
@@ -42,7 +43,9 @@ func getWorkerRoles(
 	session *session.Session,
 	awsOrgRoleAssumer awsOrgRoleAssumer,
 	orgRoles []string,
-	workerRoleName string) ([]workerRole, error) {
+	workerRoleName string,
+	skipAccts sets.StringSet,
+) ([]workerRole, error) {
 	ctx, span := beeline.StartSpan(ctx, "server_get_worker_roles")
 	defer span.Send()
 
@@ -53,13 +56,15 @@ func getWorkerRoles(
 			CredentialsChainVerboseErrors: aws.Bool(true),
 			Retryer:                       session.Config.Retryer,
 		}
-
 		orgClient := awsOrgRoleAssumer(orgAWSConfig)
 		accountList, err := getActiveAccountList(ctx, orgClient)
 		if err != nil {
 			return nil, errors.Wrap(err, "Unable to get list of AWS Profiles")
 		}
 		for _, acct := range accountList {
+			if skipAccts.ContainsElement(*acct.Name) {
+				continue
+			}
 			// create a new IAM session for each account
 			roleARN := &arn.ARN{
 				Partition: "aws",

--- a/pkg/aws_config_server/list_roles.go
+++ b/pkg/aws_config_server/list_roles.go
@@ -62,7 +62,7 @@ func getWorkerRoles(
 			return nil, errors.Wrap(err, "Unable to get list of AWS Profiles")
 		}
 		for _, acct := range accountList {
-			if skipAccts.ContainsElement(*acct.Name) {
+			if skipAccts.ContainsElement(*acct.Id) {
 				continue
 			}
 			// create a new IAM session for each account

--- a/pkg/aws_config_server/list_roles_test.go
+++ b/pkg/aws_config_server/list_roles_test.go
@@ -481,7 +481,7 @@ func TestSkipAccounts(t *testing.T) {
 	orgRoles := []string{"first"}
 	workerRoleName := "foobar"
 	skipAccountSet := sets.StringSet{}
-	skipAccountSet.Add("invalid")
+	skipAccountSet.Add("0000000000000000")
 
 	// adds some active, some inactive. returns only active
 	mock.EXPECT().

--- a/pkg/aws_config_server/webserver.go
+++ b/pkg/aws_config_server/webserver.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/chanzuckerberg/aws-oidc/pkg/okta"
+	"github.com/chanzuckerberg/go-misc/sets"
 	oidc "github.com/coreos/go-oidc"
 	"github.com/gorilla/handlers"
 	"github.com/honeycombio/beeline-go"
@@ -36,6 +37,7 @@ type AWSConfigGenerationParams struct {
 	AWSWorkerRole string
 	AWSOrgRoles   []string
 	Concurrency   int
+	SkipAccounts  sets.StringSet
 }
 
 func Health(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {


### PR DESCRIPTION
One annoying thing about this feature is that you need `--` before the `skip-accts` feature. You'll have to use the flag like this: `--skip-accts=<acctName1>,<acctName2>`. We don't have to do this for the other fields: `web-server-port` and `concurrency`.