### PR TITLE
[fix] update deprecated goreleaser tap setup

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,7 @@ release:
 
 brews:
   - description: 'A command line utility tool to help generate AWS STS credentials from an OIDC application.'
-    github:
+    tap:
       owner: chanzuckerberg
       name: homebrew-tap
     homepage: 'https://github.com/chanzuckerberg/aws-oidc'


### PR DESCRIPTION
Fixed according to this link: https://goreleaser.com/deprecations#brewsgithub
Haven't tested it yet. I'm hoping the CI checks in this PR will show if it works or not!