### PR TITLE
[fix] add goreleaser trimpath flag back

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -13,6 +13,8 @@ builds:
       - amd64
     ldflags:
       - '-w -s -X github.com/chanzuckerberg/aws-oidc/pkg/util.GitSha={{.Commit}} -X github.com/chanzuckerberg/aws-oidc/pkg/util.Version={{.Version}} -X github.com/chanzuckerberg/aws-oidc/pkg/util.Dirty=false -X github.com/chanzuckerberg/aws-oidc/pkg/util.Release=true'
+    flags:
+      - 'trimpath'
 
 dockers:
   - dockerfile: Dockerfile

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,8 @@ builds:
       - amd64
     ldflags:
       - '-w -s -X github.com/chanzuckerberg/aws-oidc/pkg/util.GitSha={{.Commit}} -X github.com/chanzuckerberg/aws-oidc/pkg/util.Version={{.Version}} -X github.com/chanzuckerberg/aws-oidc/pkg/util.Dirty=false -X github.com/chanzuckerberg/aws-oidc/pkg/util.Release=true'
+    flags:
+      - 'trimpath'
 
 dockers:
   - dockerfile: Dockerfile


### PR DESCRIPTION
There seems to be an issue with how goreleaser is set up. 
https://github.com/chanzuckerberg/aws-oidc/runs/1195329516#step:5:67