### PR TITLE
fix: broken setup scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ clean: ## clean the repo
 
 setup: # setup development dependencies
 	export GO111MODULE=on
-	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
+	go install github.com/goreleaser/goreleaser@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
 	curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- v0.9.14
 	curl -sfL https://raw.githubusercontent.com/chanzuckerberg/bff/main/download.sh | sh
 .PHONY: setup


### PR DESCRIPTION
Both of these setup scripts were not supported anymore and deprecated. See the build errors [here](https://github.com/chanzuckerberg/aws-oidc/pull/180) for reference.  We should probably update these to use release-please instead. 