### PR TITLE
fix: add docker login step to release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,14 @@ jobs:
         with:
           go-version: 1.18
         if: ${{ steps.release.outputs.release_created }}
+
+      - name: Log in to Docker GitHub registry
+        run: |
+          docker login docker.pkg.github.com -u ${GITHUB_ACTOR} -p ${GITHUB_TOKEN}
+        env:
+          GITHUB_ACTOR: ${{ secrets.CZIBUILDBOT_USERNAME }}
+          GITHUB_TOKEN: ${{ secrets.CZIBUILDBOT_GITHUB_KEY }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -97,6 +105,13 @@ jobs:
 
           git tag -a "${VERSION}" -m "${MESSAGE}"
           git push origin "${VERSION}"
+
+      - name: Log in to Docker GitHub registry
+        run: |
+          docker login docker.pkg.github.com -u ${GITHUB_ACTOR} -p ${GITHUB_TOKEN}
+        env:
+          GITHUB_ACTOR: ${{ secrets.CZIBUILDBOT_USERNAME }}
+          GITHUB_TOKEN: ${{ secrets.CZIBUILDBOT_GITHUB_KEY }}
 
       - name: Prerelease
         uses: goreleaser/goreleaser-action@v2

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -42,4 +42,4 @@ brews:
       owner: chanzuckerberg
       name: homebrew-tap
     homepage: "https://github.com/chanzuckerberg/aws-oidc"
-    test: system "#{bin}/aws-oidc-rc"
+    test: system "#{bin}/aws-oidc version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,8 +10,6 @@ builds:
       - arm64
     ldflags:
       - "-w -s -X github.com/chanzuckerberg/aws-oidc/pkg/util.GitSha={{.Commit}} -X github.com/chanzuckerberg/aws-oidc/pkg/util.Version={{.Version}} -X github.com/chanzuckerberg/aws-oidc/pkg/util.Dirty=false -X github.com/chanzuckerberg/aws-oidc/pkg/util.Release=true"
-    flags:
-      - -trimpath
 dockers:
   - dockerfile: Dockerfile
     image_templates:
@@ -33,4 +31,4 @@ brews:
       owner: chanzuckerberg
       name: homebrew-tap
     homepage: "https://github.com/chanzuckerberg/aws-oidc"
-    test: system "#{bin}/aws-oidc"
+    test: system "#{bin}/aws-oidc version"


### PR DESCRIPTION
I've been getting "no basic auth credentials" on my runs, and it's probably because I didn't include a docker login step. I added it to both release-please actions here.

I also got rid of the `trimpath` flag in the goreleaser release file and used the old "test" values from running `make release`