### PR TITLE
chore: Prevent dependabot from upgrading broken dep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  ignore:
+      # See:
+      # https://github.com/chanzuckerberg/aws-oidc/pull/362
+      # https://github.com/chanzuckerberg/aws-oidc/pull/422
+      - dependency-name: "github.com/zalando/go-keyring"


### PR DESCRIPTION
v0.2.0 has an open bug:
https://github.com/zalando/go-keyring/issues/80

And this dependency has been upgraded and then downgraded twice now. I propose that we just ignore the dependency completely until there's a known fix.