### PR TITLE
fix: Update runs-on labels in GitHub Actions workflows

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -9,7 +9,7 @@ concurrency:
     cancel-in-progress: true
 jobs:
   dependabot:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Generate token


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-3911

This PR updates 'runs-on' in GitHub Actions workflow files to use direct values instead of label arrays.