### PR TITLE
feat: add serve-imds subcommand for workload AWS auth via Okta M2M

### DIFF
--- a/.infra/prod/rolemap/rolemap.yaml
+++ b/.infra/prod/rolemap/rolemap.yaml
@@ -392,11 +392,11 @@
   okta_client_id: 0oa1bn1cw4wphTTM31t8
 - aws_account_id: "254379453707"
   aws_account_alias: edu-platform-playground
-  aws_role_arn: arn:aws:iam::254379453707:role/poweruser
+  aws_role_arn: arn:aws:iam::254379453707:role/readonly
   okta_client_id: 0oa1bn1beawf6Yt8s1t8
 - aws_account_id: "254379453707"
   aws_account_alias: edu-platform-playground
-  aws_role_arn: arn:aws:iam::254379453707:role/readonly
+  aws_role_arn: arn:aws:iam::254379453707:role/poweruser
   okta_client_id: 0oa1bn1beawf6Yt8s1t8
 - aws_account_id: "248448116955"
   aws_account_alias: czi-protocolsio
@@ -484,11 +484,11 @@
   okta_client_id: 0oa1bn1cw4wphTTM31t8
 - aws_account_id: "046341869686"
   aws_account_alias: edu-platform-staging
-  aws_role_arn: arn:aws:iam::046341869686:role/readonly
+  aws_role_arn: arn:aws:iam::046341869686:role/poweruser
   okta_client_id: 0oa1bn1beawf6Yt8s1t8
 - aws_account_id: "046341869686"
   aws_account_alias: edu-platform-staging
-  aws_role_arn: arn:aws:iam::046341869686:role/poweruser
+  aws_role_arn: arn:aws:iam::046341869686:role/readonly
   okta_client_id: 0oa1bn1beawf6Yt8s1t8
 - aws_account_id: "023695267945"
   aws_account_alias: single-cell-public

--- a/.infra/rdev/rolemap/rolemap.yaml
+++ b/.infra/rdev/rolemap/rolemap.yaml
@@ -392,11 +392,11 @@
   okta_client_id: 0oa1bn1cw4wphTTM31t8
 - aws_account_id: "254379453707"
   aws_account_alias: edu-platform-playground
-  aws_role_arn: arn:aws:iam::254379453707:role/poweruser
+  aws_role_arn: arn:aws:iam::254379453707:role/readonly
   okta_client_id: 0oa1bn1beawf6Yt8s1t8
 - aws_account_id: "254379453707"
   aws_account_alias: edu-platform-playground
-  aws_role_arn: arn:aws:iam::254379453707:role/readonly
+  aws_role_arn: arn:aws:iam::254379453707:role/poweruser
   okta_client_id: 0oa1bn1beawf6Yt8s1t8
 - aws_account_id: "248448116955"
   aws_account_alias: czi-protocolsio
@@ -484,11 +484,11 @@
   okta_client_id: 0oa1bn1cw4wphTTM31t8
 - aws_account_id: "046341869686"
   aws_account_alias: edu-platform-staging
-  aws_role_arn: arn:aws:iam::046341869686:role/readonly
+  aws_role_arn: arn:aws:iam::046341869686:role/poweruser
   okta_client_id: 0oa1bn1beawf6Yt8s1t8
 - aws_account_id: "046341869686"
   aws_account_alias: edu-platform-staging
-  aws_role_arn: arn:aws:iam::046341869686:role/poweruser
+  aws_role_arn: arn:aws:iam::046341869686:role/readonly
   okta_client_id: 0oa1bn1beawf6Yt8s1t8
 - aws_account_id: "023695267945"
   aws_account_alias: single-cell-public

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,10 @@ RUN apk update && apk --no-cache add ca-certificates curl
 COPY --from=builder /app/aws-oidc /bin/aws-oidc
 COPY ./entrypoint.sh ./entrypoint.sh
 
+# Smoke test: confirm both subcommands register and --help works. Catches
+# broken Cobra wiring at image build time.
+RUN /bin/aws-oidc serve-config --help >/dev/null \
+ && /bin/aws-oidc serve-imds --help >/dev/null
+
 CMD ["serve-config"]
 ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ $ aws-oidc check-refresh-ttl --issuer-url=<issuer url> --client-id=<client ID>
 ### version
 Prints the version of aws-oidc to stdout.
 
+### serve-imds
+Runs a long-lived credential helper for **unattended workloads** (no human in the loop). Authenticates via Okta OAuth 2.0 `client_credentials`, exchanges the resulting JWT for AWS STS credentials, and serves them on a localhost endpoint that mimics EC2 IMDSv2.
+
+Workloads such as Prometheus or the AWS CLI consume the credentials by setting `AWS_EC2_METADATA_SERVICE_ENDPOINT` to the helper's URL — the AWS SDK's default credential chain discovers them automatically and uses them for SigV4 signing.
+
+```bash
+$ aws-oidc serve-imds \
+    --client-id <okta-service-app-client-id> \
+    --client-secret-file /etc/aws-oidc/client_secret \
+    --issuer-url https://<org>.okta.com/oauth2/<custom_auth_server_id> \
+    --aws-role-arn arn:aws:iam::ACCT:role/<your-role>
+```
+
+The `--issuer-url` MUST point to an Okta **Custom** Authorization Server (not the Org / default authorization server, which issues opaque tokens that AWS STS cannot validate). All flags can be set via env vars with the `AWS_OIDC_IMDS_` prefix, e.g. `AWS_OIDC_IMDS_CLIENT_ID`.
+
+Full operator guide (Okta + AWS prerequisites, systemd unit example, Kubernetes sidecar example, troubleshooting): see [docs/serve-imds-workload-helper.md](docs/serve-imds-workload-helper.md).
+
 ## Distributed / NFS Environments
 
 In environments where many hosts share a home directory over NFS (e.g. HPC clusters, shared compute nodes), the default OIDC token cache at `~/.cache/oidc-cli/` can cause problems:

--- a/cmd/serve-imds.go
+++ b/cmd/serve-imds.go
@@ -1,0 +1,384 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/chanzuckerberg/aws-oidc/pkg/imds_server"
+	"github.com/chanzuckerberg/aws-oidc/pkg/workload_oidc"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultIMDSPort         = 9911
+	defaultBindAddress      = "127.0.0.1"
+	defaultRefreshBefore    = 5 * time.Minute
+	defaultSessionDuration  = time.Hour
+	defaultStartupFetchWait = 30 * time.Second
+	shutdownDrainTimeout    = 5 * time.Second
+)
+
+var (
+	serveIMDSClientID         string
+	serveIMDSClientSecretFile string
+	serveIMDSIssuerURL        string
+	serveIMDSAWSRoleARN       string
+	serveIMDSScope            string
+	serveIMDSAWSRegion        string
+	serveIMDSBindAddress      string
+	serveIMDSPort             int
+	serveIMDSRefreshBefore    time.Duration
+	serveIMDSSessionDuration  time.Duration
+	serveIMDSRequireV2        bool
+)
+
+func init() {
+	serveIMDSCmd.Flags().StringVar(&serveIMDSClientID, "client-id", "",
+		"Okta Service app client_id. Or set AWS_OIDC_IMDS_CLIENT_ID.")
+	serveIMDSCmd.Flags().StringVar(&serveIMDSClientSecretFile, "client-secret-file", "",
+		"Path to a file containing the Okta Service app client_secret. File MUST be mode 0600. Or set AWS_OIDC_IMDS_CLIENT_SECRET_FILE.")
+	serveIMDSCmd.Flags().StringVar(&serveIMDSIssuerURL, "issuer-url", "",
+		"Okta CUSTOM Authorization Server URL (e.g. https://example.okta.com/oauth2/aus123abc). MUST NOT be the Org/default authorization server. Or set AWS_OIDC_IMDS_ISSUER_URL.")
+	serveIMDSCmd.Flags().StringVar(&serveIMDSAWSRoleARN, "aws-role-arn", "",
+		"IAM role ARN to assume via sts:AssumeRoleWithWebIdentity. Or set AWS_OIDC_IMDS_AWS_ROLE_ARN.")
+	serveIMDSCmd.Flags().StringVar(&serveIMDSScope, "scope", "",
+		"OAuth scope to request (typically a custom scope on the Custom AS, e.g. 'aws-m2m-access'). Or set AWS_OIDC_IMDS_SCOPE.")
+	serveIMDSCmd.Flags().StringVar(&serveIMDSAWSRegion, "aws-region", "us-west-2",
+		"STS regional endpoint region. Or set AWS_OIDC_IMDS_AWS_REGION.")
+	serveIMDSCmd.Flags().StringVar(&serveIMDSBindAddress, "bind-address", defaultBindAddress,
+		"IP to bind the IMDS listener on. NEVER bind to a non-loopback address unless the helper runs in a sandboxed network namespace (e.g. K8s sidecar in same pod).")
+	serveIMDSCmd.Flags().IntVar(&serveIMDSPort, "port", defaultIMDSPort,
+		"Port to bind the IMDS listener on. Default 9911 matches AWS's aws_signing_helper.")
+	serveIMDSCmd.Flags().DurationVar(&serveIMDSRefreshBefore, "refresh-before", defaultRefreshBefore,
+		"Pre-expiry refresh window for STS credentials.")
+	serveIMDSCmd.Flags().DurationVar(&serveIMDSSessionDuration, "session-duration", defaultSessionDuration,
+		"STS DurationSeconds requested. Capped by the IAM role's MaxSessionDuration; a smaller cap on the role wins.")
+	serveIMDSCmd.Flags().BoolVar(&serveIMDSRequireV2, "require-imdsv2", false,
+		"Refuse v1-style GET requests that lack the X-Aws-Ec2-Metadata-Token header. Default false (SDK fallback compatibility).")
+
+	rootCmd.AddCommand(serveIMDSCmd)
+}
+
+// serveIMDSCmd is the workload-OIDC IMDS-mock subcommand.
+var serveIMDSCmd = &cobra.Command{
+	Use:   "serve-imds",
+	Short: "Run a localhost IMDSv2-shaped credential server backed by Okta workload OIDC",
+	Long: `serve-imds runs a long-lived credential helper that:
+
+  1. Authenticates to Okta with a Service app via OAuth 2.0 client_credentials,
+     obtaining a JWT access_token from a Custom Authorization Server.
+  2. Exchanges the JWT for AWS STS credentials via sts:AssumeRoleWithWebIdentity.
+  3. Serves the STS credentials on a localhost endpoint that mimics EC2 IMDSv2.
+
+Workloads such as Prometheus or the AWS CLI can use the served credentials by
+setting AWS_EC2_METADATA_SERVICE_ENDPOINT to the helper's URL — the AWS SDK's
+default credential chain will discover the endpoint and SigV4-sign requests
+with the served credentials transparently.
+
+The --client-secret-file MUST be mode 0600 and contain only the secret
+string. Flags can be overridden via env vars with prefix AWS_OIDC_IMDS_.`,
+	SilenceErrors: true,
+	RunE:          serveIMDSRun,
+}
+
+func serveIMDSRun(cmd *cobra.Command, _ []string) error {
+	loadServeIMDSEnv()
+
+	cfg, err := buildServeIMDSConfig()
+	if err != nil {
+		return err
+	}
+
+	clientSecret, err := readClientSecretFile(cfg.clientSecretFile)
+	if err != nil {
+		return err
+	}
+
+	oidcCfg := workload_oidc.Config{
+		ClientID:     cfg.clientID,
+		ClientSecret: clientSecret,
+		IssuerURL:    cfg.issuerURL,
+		Scopes:       cfg.scopes(),
+	}
+
+	roleName, err := roleNameFromARN(cfg.awsRoleARN)
+	if err != nil {
+		return err
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(cmd.Context(),
+		config.WithRegion(cfg.awsRegion),
+	)
+	if err != nil {
+		return fmt.Errorf("loading AWS config: %w", err)
+	}
+	stsClient := sts.NewFromConfig(awsCfg)
+
+	cache, err := imds_server.NewCredentialsCache(imds_server.NewCredentialsCacheOptions{
+		STSClient:       stsClient,
+		RoleARN:         cfg.awsRoleARN,
+		RoleSessionName: cfg.clientID, // sanitized inside getter where used by other paths; cache passes through to STS
+		SessionDuration: cfg.sessionDuration,
+		Fetcher:         oidcCfg.FetchToken,
+		RefreshBefore:   cfg.refreshBefore,
+	})
+	if err != nil {
+		return fmt.Errorf("building credentials cache: %w", err)
+	}
+
+	server, err := imds_server.NewServer(imds_server.Options{
+		RoleName:      roleName,
+		Cache:         cache,
+		RequireIMDSv2: cfg.requireIMDSv2,
+		Logger:        slog.Default(),
+	})
+	if err != nil {
+		return fmt.Errorf("building imds server: %w", err)
+	}
+
+	// Startup validation (fail-fast). Performs one Okta -> STS round-trip
+	// before binding the listener so misconfiguration produces a clear,
+	// immediate error.
+	startupCtx, startupCancel := context.WithTimeout(cmd.Context(), defaultStartupFetchWait)
+	defer startupCancel()
+	if _, err := cache.Get(startupCtx); err != nil {
+		return fmt.Errorf("startup credential fetch failed: %w", err)
+	}
+	slog.Info("imds_server: startup credential fetch succeeded",
+		slog.String("role_arn", cfg.awsRoleARN),
+		slog.Any("oidc", oidcCfg),
+	)
+
+	// Start the HTTP listener. Warn if binding to non-loopback.
+	if !isLoopbackBindAddress(cfg.bindAddress) {
+		slog.Warn("imds_server: binding to non-loopback address — anyone with network access to this host can fetch AWS credentials",
+			slog.String("bind_address", cfg.bindAddress),
+		)
+	}
+	addr := net.JoinHostPort(cfg.bindAddress, fmt.Sprintf("%d", cfg.port))
+	httpSrv := &http.Server{
+		Addr:              addr,
+		Handler:           server.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	// Graceful shutdown on SIGTERM / SIGINT.
+	rootCtx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	listenErrCh := make(chan error, 1)
+	go func() {
+		slog.Info("imds_server: listening", slog.String("addr", "http://"+addr))
+		if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			listenErrCh <- err
+			return
+		}
+		listenErrCh <- nil
+	}()
+
+	select {
+	case <-rootCtx.Done():
+		slog.Info("imds_server: shutdown signal received, draining")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownDrainTimeout)
+		defer cancel()
+		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+			slog.Error("imds_server: shutdown error", slog.String("error", err.Error()))
+		}
+		<-listenErrCh
+		return nil
+	case err := <-listenErrCh:
+		if err != nil {
+			return fmt.Errorf("imds listener: %w", err)
+		}
+		return nil
+	}
+}
+
+// serveIMDSConfig is the validated set of inputs for the subcommand.
+type serveIMDSConfig struct {
+	clientID         string
+	clientSecretFile string
+	issuerURL        string
+	awsRoleARN       string
+	scope            string
+	awsRegion        string
+	bindAddress      string
+	port             int
+	refreshBefore    time.Duration
+	sessionDuration  time.Duration
+	requireIMDSv2    bool
+}
+
+func (c serveIMDSConfig) scopes() []string {
+	if c.scope == "" {
+		return nil
+	}
+	return strings.Fields(c.scope)
+}
+
+// LogValue redacts nothing at this level (no secrets in this struct), but
+// implements LogValuer for consistent slog formatting.
+func (c serveIMDSConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("client_id", c.clientID),
+		slog.String("client_secret_file", c.clientSecretFile),
+		slog.String("issuer_url", c.issuerURL),
+		slog.String("aws_role_arn", c.awsRoleARN),
+		slog.String("scope", c.scope),
+		slog.String("aws_region", c.awsRegion),
+		slog.String("bind_address", c.bindAddress),
+		slog.Int("port", c.port),
+		slog.Duration("refresh_before", c.refreshBefore),
+		slog.Duration("session_duration", c.sessionDuration),
+		slog.Bool("require_imdsv2", c.requireIMDSv2),
+	)
+}
+
+func buildServeIMDSConfig() (serveIMDSConfig, error) {
+	if serveIMDSClientID == "" {
+		return serveIMDSConfig{}, errors.New("missing required flag/env: --client-id (AWS_OIDC_IMDS_CLIENT_ID)")
+	}
+	if serveIMDSClientSecretFile == "" {
+		return serveIMDSConfig{}, errors.New("missing required flag/env: --client-secret-file (AWS_OIDC_IMDS_CLIENT_SECRET_FILE)")
+	}
+	if serveIMDSIssuerURL == "" {
+		return serveIMDSConfig{}, errors.New("missing required flag/env: --issuer-url (AWS_OIDC_IMDS_ISSUER_URL)")
+	}
+	if serveIMDSAWSRoleARN == "" {
+		return serveIMDSConfig{}, errors.New("missing required flag/env: --aws-role-arn (AWS_OIDC_IMDS_AWS_ROLE_ARN)")
+	}
+	if !strings.HasPrefix(serveIMDSIssuerURL, "https://") && !strings.HasPrefix(serveIMDSIssuerURL, "http://") {
+		return serveIMDSConfig{}, errors.New("--issuer-url must start with http:// or https://")
+	}
+	// Defensive: catch the common "Org AS" mistake. Org AS is /oauth2/v1
+	// rather than /oauth2/<auth_server_id>. The Org AS issues opaque tokens
+	// AWS STS cannot validate.
+	if strings.HasSuffix(strings.TrimRight(serveIMDSIssuerURL, "/"), "/oauth2/v1") {
+		return serveIMDSConfig{}, fmt.Errorf("--issuer-url looks like the Okta Org Authorization Server (%s); a Custom Authorization Server is required (e.g. .../oauth2/aus<id>)", serveIMDSIssuerURL)
+	}
+	if serveIMDSPort < 1 || serveIMDSPort > 65535 {
+		return serveIMDSConfig{}, fmt.Errorf("--port out of range: %d", serveIMDSPort)
+	}
+
+	return serveIMDSConfig{
+		clientID:         serveIMDSClientID,
+		clientSecretFile: serveIMDSClientSecretFile,
+		issuerURL:        strings.TrimRight(serveIMDSIssuerURL, "/"),
+		awsRoleARN:       serveIMDSAWSRoleARN,
+		scope:            serveIMDSScope,
+		awsRegion:        serveIMDSAWSRegion,
+		bindAddress:      serveIMDSBindAddress,
+		port:             serveIMDSPort,
+		refreshBefore:    serveIMDSRefreshBefore,
+		sessionDuration:  serveIMDSSessionDuration,
+		requireIMDSv2:    serveIMDSRequireV2,
+	}, nil
+}
+
+// loadServeIMDSEnv populates flag-backing variables from AWS_OIDC_IMDS_*
+// env vars where the corresponding flag was not set on the command line.
+// Flag value takes precedence over env var.
+func loadServeIMDSEnv() {
+	type binding struct {
+		ptr    *string
+		envKey string
+	}
+	for _, b := range []binding{
+		{&serveIMDSClientID, "AWS_OIDC_IMDS_CLIENT_ID"},
+		{&serveIMDSClientSecretFile, "AWS_OIDC_IMDS_CLIENT_SECRET_FILE"},
+		{&serveIMDSIssuerURL, "AWS_OIDC_IMDS_ISSUER_URL"},
+		{&serveIMDSAWSRoleARN, "AWS_OIDC_IMDS_AWS_ROLE_ARN"},
+		{&serveIMDSScope, "AWS_OIDC_IMDS_SCOPE"},
+		{&serveIMDSAWSRegion, "AWS_OIDC_IMDS_AWS_REGION"},
+		{&serveIMDSBindAddress, "AWS_OIDC_IMDS_BIND_ADDRESS"},
+	} {
+		if *b.ptr == "" || (b.ptr == &serveIMDSAWSRegion && *b.ptr == "us-west-2") || (b.ptr == &serveIMDSBindAddress && *b.ptr == defaultBindAddress) {
+			if v := os.Getenv(b.envKey); v != "" {
+				*b.ptr = v
+			}
+		}
+	}
+}
+
+// readClientSecretFile reads the secret from disk, requires the file to be
+// mode 0600 (warns if looser, fails if missing/unreadable), and returns the
+// trimmed content. The secret is never written to logs.
+func readClientSecretFile(p string) (string, error) {
+	if p == "" {
+		return "", errors.New("--client-secret-file is empty")
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		return "", fmt.Errorf("cannot stat client_secret file %q: %w", p, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("client_secret file %q is a directory", p)
+	}
+	mode := info.Mode().Perm()
+	if mode != 0o600 {
+		slog.Warn("imds_server: client_secret file mode is not 0600",
+			slog.String("path", p),
+			slog.String("mode", fmt.Sprintf("%04o", mode)),
+			slog.String("recommended", "0600"),
+		)
+	}
+	contents, err := os.ReadFile(p)
+	if err != nil {
+		return "", fmt.Errorf("reading client_secret file %q: %w", p, err)
+	}
+	secret := strings.TrimSpace(string(contents))
+	if secret == "" {
+		return "", fmt.Errorf("client_secret file %q is empty", p)
+	}
+	return secret, nil
+}
+
+// roleNameFromARN extracts the role name from an IAM role ARN. The IMDS
+// security-credentials path uses the role name (not the full ARN).
+func roleNameFromARN(roleARN string) (string, error) {
+	const prefix = "arn:aws:iam::"
+	if !strings.HasPrefix(roleARN, prefix) {
+		return "", fmt.Errorf("invalid role ARN %q: must start with %s", roleARN, prefix)
+	}
+	rest := roleARN[len(prefix):]
+	// rest is "<account-id>:role/<name>" possibly with a path: "<account-id>:role/path/to/<name>"
+	idx := strings.Index(rest, ":role/")
+	if idx < 0 {
+		return "", fmt.Errorf("invalid role ARN %q: missing :role/ segment", roleARN)
+	}
+	rolePath := rest[idx+len(":role/"):]
+	name := path.Base(rolePath)
+	if name == "" || name == "." || name == "/" {
+		return "", fmt.Errorf("invalid role ARN %q: empty role name", roleARN)
+	}
+	return name, nil
+}
+
+// isLoopbackBindAddress returns true if the bind address is a loopback
+// address (127.0.0.0/8, ::1, "localhost", or empty).
+func isLoopbackBindAddress(addr string) bool {
+	if addr == "" || addr == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}
+
+// Reference aws to satisfy import; used when constructing aws.Config indirectly.
+var _ = aws.AnonymousCredentials{}

--- a/docs/serve-imds-workload-helper.md
+++ b/docs/serve-imds-workload-helper.md
@@ -1,0 +1,279 @@
+# Using `aws-oidc serve-imds` as a workload credential helper
+
+`aws-oidc serve-imds` runs as a long-lived process that brokers Okta OAuth 2.0 `client_credentials` into AWS STS credentials and serves them on a localhost endpoint that mimics EC2 IMDSv2. Unmodified workloads (Prometheus, AWS CLI, anything using the AWS SDK) pick up the credentials via the standard credential chain — they don't need to know `aws-oidc` exists.
+
+This document covers the operator-side setup (Okta + AWS), the producer-side runtime patterns (systemd, Kubernetes sidecar), security expectations, and the most common failure modes.
+
+## Audience
+
+Operators rolling this out for a non-EKS workload that needs to call AWS (e.g. Prometheus remote-writing to Amazon Managed Prometheus from a non-AWS host). For interactive human authentication, use `aws-oidc creds-process` / `aws-oidc exec` instead — `serve-imds` is the unattended-workload analogue.
+
+## How it fits together
+
+```
+┌─── workload host (HPC, non-EKS K8s, anything outside AWS) ───────┐
+│                                                                  │
+│   client_secret on disk                                          │
+│           │                                                      │
+│           ▼                                                      │
+│   ┌──────────────────────────┐    Okta CUSTOM Auth Server        │
+│   │ aws-oidc serve-imds      │ ─► POST /oauth2/<id>/v1/token     │
+│   │   (Okta client_creds  →  │ ◄─ access_token JWT               │
+│   │    STS AssumeRoleWith-   │                                   │
+│   │    WebIdentity  →        │ ─► AWS STS                        │
+│   │    cached  →             │ ◄─ short-lived AWS credentials    │
+│   │    serves IMDSv2         │                                   │
+│   │    on 127.0.0.1:9911)    │                                   │
+│   └─────────────┬────────────┘                                   │
+│                 │ AWS SDK credential chain                       │
+│                 │   AWS_EC2_METADATA_SERVICE_ENDPOINT=...        │
+│                 ▼                                                │
+│   ┌─────────────────────────┐                                    │
+│   │ Prometheus / AWS CLI /  │                                    │
+│   │ any AWS-SDK workload    │                                    │
+│   │   sigv4 { region: ... } │                                    │
+│   └─────────────┬───────────┘                                    │
+└─────────────────┼────────────────────────────────────────────────┘
+                  │ SigV4-signed AWS API call
+                  ▼
+                AWS service (e.g. AMP remote_write)
+```
+
+## Prerequisites — Okta side
+
+You need:
+
+1. **An Okta API Service application** (Service App, OAuth 2.0 Client Credentials grant) per workload identity:
+   - Note the `client_id` and `client_secret`.
+   - Client authentication method: `client_secret_post` (default).
+2. **A Custom Authorization Server** (NOT the Org / default Okta authorization server):
+   - The Org AS endpoint at `/oauth2/v1/token` issues **opaque** access tokens whose structure is "subject to change at any time without notice" per Okta documentation. AWS STS cannot validate them.
+   - The Custom AS endpoint is `/oauth2/<auth_server_id>/v1/token`. Tokens issued here are RS256-signed JWTs with the audience you configure.
+   - Configure the Custom AS's single `audiences` field to a stable URL like `https://aws-sts.<your-app>`.
+3. **A custom scope on the Custom AS** (e.g. `aws-m2m-access`) with `consent=IMPLICIT`, granted to the Service app.
+4. **An access policy rule** on the Custom AS allowing the Service app to use the `client_credentials` grant for the custom scope.
+
+Reference walkthrough: [okta-aws-cli M2M Command Requirements](https://github.com/okta/okta-aws-cli#m2m-command-requirements). Their setup uses `private_key_jwt` rather than `client_secret_post` but the AWS-side configuration is identical.
+
+## Prerequisites — AWS side
+
+You need three IAM resources in the account that holds the target role:
+
+1. **An IAM OIDC identity provider**:
+   - URL: the Custom AS URL with no trailing slash and exact casing — e.g. `https://<org>.okta.com/oauth2/aus123abc`.
+   - Client ID list: contains your Custom AS audience value, e.g. `["https://aws-sts.<your-app>"]`.
+2. **A target IAM role** with a trust policy allowing `sts:AssumeRoleWithWebIdentity` from the OIDC provider, conditioned on the audience and (preferably) the Service app's client_id:
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [{
+       "Effect": "Allow",
+       "Principal": {
+         "Federated": "arn:aws:iam::ACCT:oidc-provider/<org>.okta.com/oauth2/aus123abc"
+       },
+       "Action": "sts:AssumeRoleWithWebIdentity",
+       "Condition": {
+         "StringEquals": {
+           "<org>.okta.com/oauth2/aus123abc:aud": "https://aws-sts.<your-app>",
+           "<org>.okta.com/oauth2/aus123abc:sub": "0oaSERVICEAPPCLIENTID"
+         }
+       }
+     }]
+   }
+   ```
+   Use `:aud` and `:sub`. Do **not** use `:azp` — Okta's default token profile does not emit an `azp` claim (it uses `cid` for the client ID instead, and the IAM trust-policy condition keys cover `aud`/`sub`/`amr`/`auth_time`/`iat`/`iss`).
+3. **The role's permission policy** should grant only what the workload needs. For example, AMP remote-write would be `aps:RemoteWrite` on a specific workspace ARN.
+
+### The audience-three-way coupling
+
+The audience value MUST be **identical** in three places:
+
+- The Custom AS's `audiences` field (Okta stamps this into the JWT's `aud` claim).
+- The IAM OIDC provider's `client_id_list` (AWS validates `aud` against this list).
+- The role trust policy's `Condition` on `<issuer>:aud`.
+
+A single mismatch produces an `InvalidIdentityToken` / "Token does not match expected audience" error from STS, which is hard to debug downstream. **Decide on the audience value first, before configuring anything.**
+
+### R1 verification recipe
+
+Before deploying the helper to a real workload, verify the round-trip works in your tenant. From a shell with AWS credentials that can call STS:
+
+```bash
+# 1. Get an access token from your Custom AS.
+TOKEN=$(curl -s -X POST \
+  -d "grant_type=client_credentials" \
+  -d "client_id=$CLIENT_ID" \
+  -d "client_secret=$CLIENT_SECRET" \
+  -d "scope=$SCOPE" \
+  "https://$OKTA_DOMAIN/oauth2/$AUTH_SERVER_ID/v1/token" \
+  | jq -r .access_token)
+
+# 2. Decode the JWT and confirm `aud` and `sub`.
+echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq
+
+# 3. Exchange it via STS.
+aws sts assume-role-with-web-identity \
+  --role-arn "$ROLE_ARN" \
+  --role-session-name "$CLIENT_ID" \
+  --web-identity-token "$TOKEN"
+```
+
+If step 3 returns 200, the Okta + AWS configuration is correct and `serve-imds` will work. If it returns `InvalidIdentityToken`, check the audience-three-way-coupling above before debugging anything else.
+
+## Producer-side: Linux + systemd
+
+For an HPC head node or any standalone Linux host:
+
+```ini
+# /etc/systemd/system/aws-oidc-serve-imds.service
+[Unit]
+Description=aws-oidc serve-imds (workload OIDC -> AWS STS -> IMDS)
+Wants=network-online.target chronyd.service
+After=network-online.target chronyd.service
+
+[Service]
+Type=simple
+DynamicUser=yes
+SupplementaryGroups=aws-oidc-secret-readers
+ExecStart=/usr/local/bin/aws-oidc serve-imds
+EnvironmentFile=/etc/aws-oidc/imds.env
+Restart=on-failure
+RestartSec=5s
+
+ProtectSystem=strict
+ProtectHome=yes
+NoNewPrivileges=yes
+ReadOnlyPaths=/etc/aws-oidc
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+# /etc/aws-oidc/imds.env  (mode 0644, contains no secret)
+AWS_OIDC_IMDS_CLIENT_ID=0oa...
+AWS_OIDC_IMDS_CLIENT_SECRET_FILE=/etc/aws-oidc/client_secret
+AWS_OIDC_IMDS_ISSUER_URL=https://example.okta.com/oauth2/aus123abc
+AWS_OIDC_IMDS_AWS_ROLE_ARN=arn:aws:iam::123456789012:role/argus-amp-producer-bruno
+AWS_OIDC_IMDS_SCOPE=aws-m2m-access
+AWS_OIDC_IMDS_AWS_REGION=us-west-2
+```
+
+The `client_secret` file should be `0600`, owned by `root:aws-oidc-secret-readers`. The helper runs under `DynamicUser=yes` and is added to that group via `SupplementaryGroups`, so it can read the secret without root.
+
+For Prometheus on the same host, edit its systemd unit:
+
+```ini
+[Service]
+Environment=AWS_EC2_METADATA_SERVICE_ENDPOINT=http://127.0.0.1:9911
+Environment=AWS_REGION=us-west-2
+
+[Unit]
+After=aws-oidc-serve-imds.service
+Requires=aws-oidc-serve-imds.service
+```
+
+Drop the `access_key` / `secret_key` fields from the `sigv4` block in `prometheus.yml`. Leave `region`. The AWS SDK chain inside Prometheus will discover credentials via the local IMDS endpoint.
+
+## Producer-side: Kubernetes sidecar (non-EKS)
+
+For a Prometheus pod in a non-EKS cluster (e.g. CoreWeave):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-oidc-imds
+  namespace: monitoring
+type: Opaque
+stringData:
+  client_secret: "<okta-client-secret>"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-oidc-imds
+  namespace: monitoring
+data:
+  AWS_OIDC_IMDS_CLIENT_ID: "0oa..."
+  AWS_OIDC_IMDS_CLIENT_SECRET_FILE: "/etc/aws-oidc/client_secret"
+  AWS_OIDC_IMDS_ISSUER_URL: "https://example.okta.com/oauth2/aus123abc"
+  AWS_OIDC_IMDS_AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/argus-amp-producer-cw"
+  AWS_OIDC_IMDS_SCOPE: "aws-m2m-access"
+  AWS_OIDC_IMDS_AWS_REGION: "us-west-2"
+---
+# Sidecar container in the Prometheus pod
+spec:
+  containers:
+    - name: prometheus
+      image: prom/prometheus:v2.x
+      env:
+        - name: AWS_EC2_METADATA_SERVICE_ENDPOINT
+          value: http://127.0.0.1:9911
+        - name: AWS_REGION
+          value: us-west-2
+      # ... your existing prometheus config
+
+    - name: aws-oidc-serve-imds
+      image: <your-registry>/aws-oidc:latest
+      args: ["serve-imds"]
+      envFrom:
+        - configMapRef:
+            name: aws-oidc-imds
+      volumeMounts:
+        - name: client-secret
+          mountPath: /etc/aws-oidc
+          readOnly: true
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: 9911
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 9911
+
+  volumes:
+    - name: client-secret
+      secret:
+        secretName: aws-oidc-imds
+        items:
+          - key: client_secret
+            path: client_secret
+            mode: 0o600
+```
+
+The two containers share the pod's network namespace, so Prometheus reaches the helper at `127.0.0.1:9911` without crossing any pod or host boundary. No other pod can reach the helper.
+
+## Security notes
+
+- **`client_secret` hygiene.** The file MUST be mode `0600`. The helper warns at startup if it's looser; do not ignore that warning. The secret is never written to logs (`workload_oidc.Config.LogValue` redacts it at all slog levels).
+- **Bind address.** Default is `127.0.0.1`. The helper warns at startup if you set it to a non-loopback address. K8s sidecar deployments are safe because the pod's network namespace contains only the helper and the workload.
+- **TLS.** Not used on the local IMDS endpoint, matching real EC2 IMDS behavior. The trust boundary is "anything that can reach 127.0.0.1 on this host can fetch credentials" — same as real EC2.
+- **IMDSv2 token TTL.** Default 6 hours, the AWS-documented maximum. Use `--require-imdsv2` to refuse v1-style requests for stricter posture.
+- **Secret rotation requires restart.** The helper reads `client_secret` once at startup. If you rotate the Okta client_secret, restart the helper. Periodic re-read is not currently supported.
+- **CloudTrail attribution.** The role session name passed to `AssumeRoleWithWebIdentity` is the OAuth `client_id`, which is also what Okta puts in the JWT's `sub` claim — so trust-policy conditions, the JWT, and the role session name all line up to the same identifier. CloudTrail's `userIdentity.userName` for downstream API calls shows `<role-name>/<client_id>`.
+
+## Operational notes
+
+- **Startup validation.** On startup, the helper performs one full Okta → STS round trip before binding the listener. Misconfiguration (bad client_secret, wrong audience, role trust policy mismatch, network) produces an immediate, clear error rather than a silent failure at first request.
+- **Refresh.** The `aws.CredentialsCache` underneath refreshes credentials 5 minutes before expiry by default (`--refresh-before`). Concurrent IMDS requests during a refresh are coalesced into one Okta + STS round trip.
+- **Graceful shutdown.** SIGTERM / SIGINT triggers `http.Server.Shutdown` with a 5-second drain window, after which the process exits cleanly.
+- **Multiple identities on one host.** The helper serves one role per process. To serve multiple roles, run multiple processes on different `--port`s and point each consumer's `AWS_EC2_METADATA_SERVICE_ENDPOINT` accordingly.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `InvalidIdentityToken` / "Token does not match expected audience" | The Custom AS audience config doesn't match the IAM OIDC provider `client_id_list` or the trust policy's `aud` condition. Decode the JWT (`echo $TOKEN \| cut -d. -f2 \| base64 -d`) and compare. |
+| `IDPCommunicationError` from STS | AWS can't fetch the OIDC discovery document. Check that the IAM OIDC provider URL (no trailing slash, exact casing) resolves and the JWKS endpoint is reachable from AWS. Custom Okta domains need a publicly trusted TLS chain. |
+| `InvalidIdentityToken: Couldn't retrieve verification key` | The JWT is signed with a key that's not in the JWKS, or the issuer URL casing doesn't match. Or you're hitting the Org AS instead of a Custom AS — the helper warns about this at startup but check anyway. |
+| `InvalidParameterException: 1 validation error detected: Value '...' at 'roleSessionName' failed to satisfy constraint` | The OAuth `client_id` contains characters STS rejects in `RoleSessionName`. Open an issue; the helper sanitizes session names but unusual `client_id`s can still land here. |
+| Prometheus shows `failed to retrieve credentials` from IMDS | The helper isn't running, isn't bound to the right address/port, or `AWS_EC2_METADATA_SERVICE_ENDPOINT` isn't set in the Prometheus process. Check `journalctl -u aws-oidc-serve-imds` (Linux) or `kubectl logs ... -c aws-oidc-serve-imds` (K8s). |
+| Helper logs `transient error, retrying` | Okta /token returned 5xx. Self-heals after up to 3 retries with exponential backoff; persistent failure produces `failed startup credential fetch` and the process exits. |
+
+## What's NOT included
+
+- This subcommand does not provision the Okta Service app, the AWS IAM OIDC provider, or the IAM role. Those are operator tasks (Terraform / Okta admin / AWS console).
+- It does not rotate the `client_secret`. Restart the helper after rotation.
+- It does not refresh the cert chain for self-hosted issuer URLs (none used by default).

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,11 @@ toolchain go1.24.1
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/aws/aws-sdk-go v1.55.8
+	github.com/aws/aws-sdk-go-v2 v1.41.6
+	github.com/aws/aws-sdk-go-v2/config v1.32.16
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22
+	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/chanzuckerberg/go-misc/oidc/v5 v5.0.0-20260226201707-b3b2ff0ceb08
 	github.com/chanzuckerberg/go-misc/ver v0.0.0-20251117200159-d2a50dbfd31c
@@ -16,15 +21,12 @@ require (
 	github.com/okta/okta-sdk-golang/v3 v3.0.19
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/oauth2 v0.33.0
 	gopkg.in/ini.v1 v1.67.0
 )
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.6 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.16 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.15 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 // indirect
@@ -33,7 +35,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0 // indirect
 	github.com/aws/smithy-go v1.25.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
@@ -52,7 +53,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
@@ -68,12 +68,10 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/zalando/go-keyring v0.2.6 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/oauth2 v0.33.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	gopkg.in/go-jose/go-jose.v2 v2.6.3 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bww
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
@@ -209,9 +207,6 @@ gopkg.in/go-jose/go-jose.v2 v2.6.3 h1:nt80fvSDlhKWQgSWyHyy5CfmlQr+asih51R8PTWNKK
 gopkg.in/go-jose/go-jose.v2 v2.6.3/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/getter/aws_creds.go
+++ b/pkg/getter/aws_creds.go
@@ -3,6 +3,8 @@ package getter
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -11,39 +13,101 @@ import (
 	"github.com/chanzuckerberg/go-misc/oidc/v5/cli/client"
 )
 
+// stsSessionNameInvalid matches characters NOT permitted in the STS
+// RoleSessionName. The valid set is alphanumeric plus =,.@_-
+var stsSessionNameInvalid = regexp.MustCompile(`[^A-Za-z0-9=,.@_-]`)
+
+// stsSessionNameMaxLen is the AWS STS RoleSessionName length cap.
+const stsSessionNameMaxLen = 64
+
+// GetAWSAssumeIdentity exchanges a chanzuckerberg/go-misc OIDC token for an
+// AWS STS session by calling sts:AssumeRoleWithWebIdentity. This is the
+// human-flow path; the role session name is derived from the token's email
+// (or preferredUsername) claim.
+//
+// For workload (non-human) flows, prefer AssumeRoleWithJWT, which takes a
+// raw JWT and an explicit session name.
 func GetAWSAssumeIdentity(
 	ctx context.Context,
 	token *client.Token,
 	roleARN string,
 	sessionDuration time.Duration,
 ) (*sts.AssumeRoleWithWebIdentityOutput, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
+	sessionName := token.Claims.Email
+	if sessionName == "" {
+		sessionName = token.Claims.PreferredUsername
+		if sessionName == "" {
+			sessionName = "unknown-username"
+		}
+	}
+	return AssumeRoleWithJWT(ctx, token.IDToken, sessionName, roleARN, sessionDuration)
+}
+
+// AssumeRoleWithJWT calls sts:AssumeRoleWithWebIdentity with the given JWT.
+// The session name is sanitized to satisfy the STS RoleSessionName regex
+// ([A-Za-z0-9=,.@_-]+), truncated to 64 characters. AWS region and other
+// SDK configuration are read from the default credential chain (env, shared
+// config); callers may pass optional optFns to override (useful for tests
+// that need a custom BaseEndpoint).
+//
+// This is the workload-flow entry point: for example, a JWT obtained via
+// Okta's OAuth 2.0 client_credentials grant can be exchanged here for STS
+// credentials usable to sign AWS API requests.
+func AssumeRoleWithJWT(
+	ctx context.Context,
+	jwt string,
+	sessionName string,
+	roleARN string,
+	sessionDuration time.Duration,
+	optFns ...func(*config.LoadOptions) error,
+) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	if jwt == "" {
+		return nil, fmt.Errorf("AssumeRoleWithJWT: empty JWT")
+	}
+	if roleARN == "" {
+		return nil, fmt.Errorf("AssumeRoleWithJWT: empty roleARN")
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
 	if err != nil {
 		return nil, fmt.Errorf("loading AWS config: %w", err)
 	}
 
-	roleSessionName := token.Claims.Email
-	if roleSessionName == "" {
-		roleSessionName = token.Claims.PreferredUsername
-		if roleSessionName == "" {
-			roleSessionName = "unknown-username"
-		}
-	}
+	cleanedSessionName := sanitizeSessionName(sessionName)
 
 	stsClient := sts.NewFromConfig(cfg)
-	sessionDurationSeconds := int32(sessionDuration.Seconds())
+	durationSeconds := int32(sessionDuration.Seconds())
 	input := &sts.AssumeRoleWithWebIdentityInput{
 		RoleArn:          aws.String(roleARN),
-		RoleSessionName:  &roleSessionName,
-		WebIdentityToken: aws.String(token.IDToken),
-		DurationSeconds:  &sessionDurationSeconds,
+		RoleSessionName:  aws.String(cleanedSessionName),
+		WebIdentityToken: aws.String(jwt),
+		DurationSeconds:  &durationSeconds,
 	}
-	tokenOutput, err := stsClient.AssumeRoleWithWebIdentity(ctx, input)
+	out, err := stsClient.AssumeRoleWithWebIdentity(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("assuming role with web identity: %w", err)
 	}
-	if tokenOutput == nil {
-		return nil, fmt.Errorf("nil Token from AWS")
+	if out == nil {
+		return nil, fmt.Errorf("nil token from AWS STS")
 	}
-	return tokenOutput, nil
+	return out, nil
+}
+
+// sanitizeSessionName returns a string that satisfies the STS RoleSessionName
+// regex `[A-Za-z0-9=,.@_-]+` and length cap of 64. Disallowed characters are
+// replaced with `-`. Leading/trailing `-` are stripped. Empty input yields
+// "session" so the caller never has to pass a guaranteed-valid string.
+func sanitizeSessionName(s string) string {
+	if s == "" {
+		return "session"
+	}
+	cleaned := stsSessionNameInvalid.ReplaceAllString(s, "-")
+	cleaned = strings.Trim(cleaned, "-")
+	if cleaned == "" {
+		return "session"
+	}
+	if len(cleaned) > stsSessionNameMaxLen {
+		cleaned = cleaned[:stsSessionNameMaxLen]
+	}
+	return cleaned
 }

--- a/pkg/getter/aws_creds_test.go
+++ b/pkg/getter/aws_creds_test.go
@@ -1,0 +1,36 @@
+package getter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeSessionName(t *testing.T) {
+	cases := map[string]struct {
+		in   string
+		want string
+	}{
+		"alphanumeric passthrough":       {"abc123XYZ", "abc123XYZ"},
+		"valid punctuation passthrough":  {"a.b@c=d,e_f-g", "a.b@c=d,e_f-g"},
+		"spaces become hyphens":          {"hello world", "hello-world"},
+		"slash becomes hyphen":           {"name/with/slash", "name-with-slash"},
+		"colon becomes hyphen":           {"role:session:1", "role-session-1"},
+		"leading and trailing junk strip": {"!!!ok!!!", "ok"},
+		"empty input":                    {"", "session"},
+		"only invalid chars":             {"!!!", "session"},
+		"client_id form":                 {"0oa1b2c3d4e5f6", "0oa1b2c3d4e5f6"},
+		"long input truncated":           {strings.Repeat("a", 80), strings.Repeat("a", 64)},
+		"email-style passthrough":        {"alice@example.com", "alice@example.com"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			got := sanitizeSessionName(tc.in)
+			r.Equal(tc.want, got)
+			r.LessOrEqual(len(got), stsSessionNameMaxLen)
+			r.NotEmpty(got)
+		})
+	}
+}

--- a/pkg/imds_server/cache.go
+++ b/pkg/imds_server/cache.go
@@ -1,0 +1,139 @@
+package imds_server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// TokenFetcher is the function signature for obtaining a fresh JWT to
+// exchange for STS credentials. workload_oidc.Config.FetchToken satisfies
+// this signature.
+type TokenFetcher func(ctx context.Context) (jwt string, expiresAt time.Time, err error)
+
+// CredentialsCache wraps an aws.CredentialsCache fed by a
+// stscreds.WebIdentityRoleProvider whose IdentityTokenRetriever calls a
+// caller-provided TokenFetcher. The aws.CredentialsCache handles pre-expiry
+// refresh and concurrent-caller coalescing internally.
+type CredentialsCache struct {
+	inner         aws.CredentialsProvider
+	everSucceeded atomic.Bool
+}
+
+// NewCredentialsCacheOptions configures NewCredentialsCache. Required fields:
+// STSClient, RoleARN, Fetcher.
+type NewCredentialsCacheOptions struct {
+	// STSClient is the AWS STS client used to call AssumeRoleWithWebIdentity.
+	// Construct with sts.NewFromConfig(cfg). For tests, pass a client whose
+	// config.BaseEndpoint points at a mock HTTP server.
+	STSClient *sts.Client
+
+	// RoleARN is the IAM role to assume.
+	RoleARN string
+
+	// RoleSessionName is the session name used in the AssumeRole call. The
+	// caller is responsible for any sanitization (see getter.sanitizeSessionName).
+	RoleSessionName string
+
+	// SessionDuration is the requested STS DurationSeconds. Capped by the
+	// IAM role's MaxSessionDuration; if SessionDuration > role cap, STS
+	// rejects the request.
+	SessionDuration time.Duration
+
+	// Fetcher returns a fresh JWT to be exchanged for STS credentials.
+	Fetcher TokenFetcher
+
+	// RefreshBefore is the pre-expiry window in which a Retrieve call will
+	// trigger a refresh. Default: 5 minutes.
+	RefreshBefore time.Duration
+
+	// TokenFetchTimeout bounds how long a single Fetcher call may take.
+	// Default: 30 seconds.
+	TokenFetchTimeout time.Duration
+}
+
+// NewCredentialsCache builds a CredentialsCache around
+// stscreds.WebIdentityRoleProvider and aws.CredentialsCache.
+func NewCredentialsCache(opts NewCredentialsCacheOptions) (*CredentialsCache, error) {
+	if opts.STSClient == nil {
+		return nil, errors.New("imds_server: NewCredentialsCache: STSClient is required")
+	}
+	if opts.RoleARN == "" {
+		return nil, errors.New("imds_server: NewCredentialsCache: RoleARN is required")
+	}
+	if opts.Fetcher == nil {
+		return nil, errors.New("imds_server: NewCredentialsCache: Fetcher is required")
+	}
+
+	fetchTimeout := opts.TokenFetchTimeout
+	if fetchTimeout == 0 {
+		fetchTimeout = 30 * time.Second
+	}
+
+	retriever := tokenRetrieverFn(func() ([]byte, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+		defer cancel()
+		jwt, _, err := opts.Fetcher(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("fetching identity token: %w", err)
+		}
+		if jwt == "" {
+			return nil, errors.New("fetcher returned empty JWT")
+		}
+		return []byte(jwt), nil
+	})
+
+	provider := stscreds.NewWebIdentityRoleProvider(
+		opts.STSClient,
+		opts.RoleARN,
+		retriever,
+		func(o *stscreds.WebIdentityRoleOptions) {
+			o.RoleSessionName = opts.RoleSessionName
+			if opts.SessionDuration > 0 {
+				o.Duration = opts.SessionDuration
+			}
+		},
+	)
+
+	refreshBefore := opts.RefreshBefore
+	if refreshBefore == 0 {
+		refreshBefore = 5 * time.Minute
+	}
+
+	cached := aws.NewCredentialsCache(provider, func(o *aws.CredentialsCacheOptions) {
+		o.ExpiryWindow = refreshBefore
+		o.ExpiryWindowJitterFrac = 0.2
+	})
+
+	return &CredentialsCache{inner: cached}, nil
+}
+
+// Get returns current credentials, refreshing via the underlying provider if
+// the cached credentials are within the configured RefreshBefore window of
+// expiry. Concurrent callers are coalesced by aws.CredentialsCache so a
+// single refresh is shared across them.
+func (c *CredentialsCache) Get(ctx context.Context) (aws.Credentials, error) {
+	creds, err := c.inner.Retrieve(ctx)
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("retrieving credentials: %w", err)
+	}
+	c.everSucceeded.Store(true)
+	return creds, nil
+}
+
+// Ready reports whether the cache has produced at least one successful
+// credential retrieval since startup. Used to drive readiness probes.
+func (c *CredentialsCache) Ready() bool {
+	return c.everSucceeded.Load()
+}
+
+// tokenRetrieverFn adapts a function to stscreds.IdentityTokenRetriever.
+type tokenRetrieverFn func() ([]byte, error)
+
+func (f tokenRetrieverFn) GetIdentityToken() ([]byte, error) { return f() }

--- a/pkg/imds_server/cache_test.go
+++ b/pkg/imds_server/cache_test.go
@@ -1,0 +1,257 @@
+package imds_server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/require"
+)
+
+// stsResponseXML returns a valid AssumeRoleWithWebIdentity XML response with
+// the given expiry. The SDK parses this format by default.
+func stsResponseXML(accessKey, secretKey, sessionToken string, expiry time.Time) string {
+	return fmt.Sprintf(`<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <SubjectFromWebIdentityToken>0oa1234567890</SubjectFromWebIdentityToken>
+    <Audience>https://test-audience</Audience>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/TestRole/test-session</Arn>
+      <AssumedRoleId>AROATEST:test-session</AssumedRoleId>
+    </AssumedRoleUser>
+    <Provider>example.okta.com/oauth2/aus123</Provider>
+    <Credentials>
+      <AccessKeyId>%s</AccessKeyId>
+      <SecretAccessKey>%s</SecretAccessKey>
+      <SessionToken>%s</SessionToken>
+      <Expiration>%s</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+  <ResponseMetadata>
+    <RequestId>req-1</RequestId>
+  </ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>`, accessKey, secretKey, sessionToken, expiry.UTC().Format(time.RFC3339))
+}
+
+// newMockSTS returns an httptest.Server that responds to
+// AssumeRoleWithWebIdentity with the given expiry, and an atomic counter.
+func newMockSTS(t *testing.T, expiry time.Time) (*httptest.Server, *atomic.Int32, *sts.Client) {
+	t.Helper()
+	var calls atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "text/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(stsResponseXML(
+			fmt.Sprintf("AKIA%d", calls.Load()),
+			fmt.Sprintf("secret-%d", calls.Load()),
+			fmt.Sprintf("token-%d", calls.Load()),
+			expiry,
+		)))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg, err := config.LoadDefaultConfig(context.Background(),
+		config.WithRegion("us-west-2"),
+		config.WithCredentialsProvider(aws.AnonymousCredentials{}),
+	)
+	require.NoError(t, err)
+	stsClient := sts.NewFromConfig(cfg, func(o *sts.Options) {
+		o.BaseEndpoint = aws.String(server.URL)
+	})
+
+	return server, &calls, stsClient
+}
+
+func TestCredentialsCache_Get_FirstCallFetches(t *testing.T) {
+	r := require.New(t)
+	expiry := time.Now().Add(1 * time.Hour)
+	_, calls, stsClient := newMockSTS(t, expiry)
+
+	var fetcherCalls atomic.Int32
+	cache, err := NewCredentialsCache(NewCredentialsCacheOptions{
+		STSClient:       stsClient,
+		RoleARN:         "arn:aws:iam::123456789012:role/TestRole",
+		RoleSessionName: "test-session",
+		Fetcher: func(ctx context.Context) (string, time.Time, error) {
+			fetcherCalls.Add(1)
+			return "fake.jwt", time.Now().Add(time.Hour), nil
+		},
+	})
+	r.NoError(err)
+	r.False(cache.Ready())
+
+	creds, err := cache.Get(context.Background())
+	r.NoError(err)
+	r.Equal("AKIA1", creds.AccessKeyID)
+	r.True(cache.Ready())
+	r.Equal(int32(1), calls.Load())
+	r.Equal(int32(1), fetcherCalls.Load())
+}
+
+func TestCredentialsCache_Get_SecondCallCached(t *testing.T) {
+	r := require.New(t)
+	expiry := time.Now().Add(1 * time.Hour) // well above the 5m refresh window
+	_, calls, stsClient := newMockSTS(t, expiry)
+
+	var fetcherCalls atomic.Int32
+	cache, err := NewCredentialsCache(NewCredentialsCacheOptions{
+		STSClient:       stsClient,
+		RoleARN:         "arn:aws:iam::123456789012:role/TestRole",
+		RoleSessionName: "test-session",
+		Fetcher: func(ctx context.Context) (string, time.Time, error) {
+			fetcherCalls.Add(1)
+			return "fake.jwt", time.Now().Add(time.Hour), nil
+		},
+	})
+	r.NoError(err)
+
+	for range 5 {
+		_, err := cache.Get(context.Background())
+		r.NoError(err)
+	}
+	// Only the first call should hit STS.
+	r.Equal(int32(1), calls.Load(), "expected exactly 1 STS call across 5 Get calls")
+	r.Equal(int32(1), fetcherCalls.Load())
+}
+
+func TestCredentialsCache_Get_RefreshAfterExpiry(t *testing.T) {
+	r := require.New(t)
+	// Expiry is in the past so every call refreshes.
+	expiry := time.Now().Add(-1 * time.Minute)
+	_, calls, stsClient := newMockSTS(t, expiry)
+
+	cache, err := NewCredentialsCache(NewCredentialsCacheOptions{
+		STSClient:       stsClient,
+		RoleARN:         "arn:aws:iam::123456789012:role/TestRole",
+		RoleSessionName: "test-session",
+		Fetcher: func(ctx context.Context) (string, time.Time, error) {
+			return "fake.jwt", time.Now(), nil
+		},
+		// Tiny refresh window so we can reason about it.
+		RefreshBefore: 1 * time.Second,
+	})
+	r.NoError(err)
+
+	for range 3 {
+		_, err := cache.Get(context.Background())
+		r.NoError(err)
+	}
+	// Each Get sees expired creds and refreshes.
+	r.Equal(int32(3), calls.Load(), "every call should refresh because creds are expired")
+}
+
+func TestCredentialsCache_Get_ConcurrentCoalesced(t *testing.T) {
+	r := require.New(t)
+	// Slow STS so multiple concurrent calls overlap.
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		calls.Add(1)
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(stsResponseXML("AKIATEST", "secret", "token", time.Now().Add(1*time.Hour))))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg, err := config.LoadDefaultConfig(context.Background(),
+		config.WithRegion("us-west-2"),
+		config.WithCredentialsProvider(aws.AnonymousCredentials{}),
+	)
+	r.NoError(err)
+	stsClient := sts.NewFromConfig(cfg, func(o *sts.Options) {
+		o.BaseEndpoint = aws.String(server.URL)
+	})
+
+	cache, err := NewCredentialsCache(NewCredentialsCacheOptions{
+		STSClient:       stsClient,
+		RoleARN:         "arn:aws:iam::123456789012:role/TestRole",
+		RoleSessionName: "test-session",
+		Fetcher: func(ctx context.Context) (string, time.Time, error) {
+			return "fake.jwt", time.Now().Add(time.Hour), nil
+		},
+	})
+	r.NoError(err)
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := cache.Get(context.Background())
+			r.NoError(err)
+		}()
+	}
+	wg.Wait()
+	// aws.CredentialsCache coalesces concurrent calls — exactly 1 STS call.
+	r.Equal(int32(1), calls.Load(), "concurrent Get calls should be coalesced into a single STS call")
+}
+
+func TestCredentialsCache_Get_FetcherError(t *testing.T) {
+	r := require.New(t)
+	_, _, stsClient := newMockSTS(t, time.Now().Add(time.Hour))
+
+	cache, err := NewCredentialsCache(NewCredentialsCacheOptions{
+		STSClient:       stsClient,
+		RoleARN:         "arn:aws:iam::123456789012:role/TestRole",
+		RoleSessionName: "test-session",
+		Fetcher: func(ctx context.Context) (string, time.Time, error) {
+			return "", time.Time{}, errors.New("okta unreachable")
+		},
+	})
+	r.NoError(err)
+
+	_, err = cache.Get(context.Background())
+	r.Error(err)
+	r.Contains(err.Error(), "okta unreachable")
+	r.False(cache.Ready())
+}
+
+func TestCredentialsCache_Get_EmptyJWTError(t *testing.T) {
+	r := require.New(t)
+	_, _, stsClient := newMockSTS(t, time.Now().Add(time.Hour))
+
+	cache, err := NewCredentialsCache(NewCredentialsCacheOptions{
+		STSClient:       stsClient,
+		RoleARN:         "arn:aws:iam::123456789012:role/TestRole",
+		RoleSessionName: "test-session",
+		Fetcher: func(ctx context.Context) (string, time.Time, error) {
+			return "", time.Time{}, nil
+		},
+	})
+	r.NoError(err)
+
+	_, err = cache.Get(context.Background())
+	r.Error(err)
+	r.Contains(err.Error(), "empty JWT")
+}
+
+func TestNewCredentialsCache_RequiredFields(t *testing.T) {
+	r := require.New(t)
+	stsClient := &sts.Client{}
+
+	_, err := NewCredentialsCache(NewCredentialsCacheOptions{})
+	r.Error(err)
+	r.Contains(err.Error(), "STSClient")
+
+	_, err = NewCredentialsCache(NewCredentialsCacheOptions{STSClient: stsClient})
+	r.Error(err)
+	r.Contains(err.Error(), "RoleARN")
+
+	_, err = NewCredentialsCache(NewCredentialsCacheOptions{
+		STSClient: stsClient,
+		RoleARN:   "arn:aws:iam::123456789012:role/X",
+	})
+	r.Error(err)
+	r.Contains(err.Error(), "Fetcher")
+}

--- a/pkg/imds_server/integration_test.go
+++ b/pkg/imds_server/integration_test.go
@@ -1,0 +1,197 @@
+package imds_server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/chanzuckerberg/aws-oidc/pkg/workload_oidc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_FullPipeline wires the entire stack end-to-end:
+//
+//	Okta (httptest) -> workload_oidc -> stscreds -> STS (httptest)
+//	-> CredentialsCache -> imds_server -> AWS SDK IMDS client
+//
+// Verifies that the AWS SDK's IMDS provider can fetch credentials from our
+// server and that those credentials match what the STS stub vended.
+func TestIntegration_FullPipeline(t *testing.T) {
+	r := require.New(t)
+
+	// 1. Mock Okta /v1/token endpoint.
+	var oktaCalls atomic.Int32
+	oktaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal("/v1/token", req.URL.Path)
+		r.NoError(req.ParseForm())
+		r.Equal("client_credentials", req.Form.Get("grant_type"))
+		r.Equal("test-client", req.Form.Get("client_id"))
+		r.Equal("test-secret", req.Form.Get("client_secret"))
+		// We must NOT send audience.
+		r.Empty(req.Form.Get("audience"))
+
+		oktaCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "fake.jwt.token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer oktaServer.Close()
+
+	// 2. Mock AWS STS AssumeRoleWithWebIdentity.
+	var stsCalls atomic.Int32
+	stsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		stsCalls.Add(1)
+		// Verify STS sees the JWT we got from Okta.
+		r.NoError(req.ParseForm())
+		r.Equal("fake.jwt.token", req.Form.Get("WebIdentityToken"))
+		r.Equal("arn:aws:iam::123456789012:role/argus-amp-producer-test", req.Form.Get("RoleArn"))
+
+		w.Header().Set("Content-Type", "text/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(stsResponseXML(
+			fmt.Sprintf("AKIA-INTEGRATION-%d", stsCalls.Load()),
+			fmt.Sprintf("secret-integration-%d", stsCalls.Load()),
+			fmt.Sprintf("token-integration-%d", stsCalls.Load()),
+			time.Now().Add(time.Hour).UTC(),
+		)))
+	}))
+	defer stsServer.Close()
+
+	// 3. Build the workload_oidc Config pointed at the mock Okta.
+	oidcCfg := workload_oidc.Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		IssuerURL:    oktaServer.URL,
+	}
+
+	// 4. Build an STS client pointed at the mock STS.
+	awsCfg, err := config.LoadDefaultConfig(context.Background(),
+		config.WithRegion("us-west-2"),
+		config.WithCredentialsProvider(aws.AnonymousCredentials{}),
+	)
+	r.NoError(err)
+	stsClient := sts.NewFromConfig(awsCfg, func(o *sts.Options) {
+		o.BaseEndpoint = aws.String(stsServer.URL)
+	})
+
+	// 5. Wire the cache.
+	cache, err := NewCredentialsCache(NewCredentialsCacheOptions{
+		STSClient:       stsClient,
+		RoleARN:         "arn:aws:iam::123456789012:role/argus-amp-producer-test",
+		RoleSessionName: "test-client",
+		SessionDuration: time.Hour,
+		Fetcher:         oidcCfg.FetchToken,
+	})
+	r.NoError(err)
+
+	// 6. Spin up the IMDS server in front of a real http.Server.
+	srv, err := NewServer(Options{
+		RoleName: "argus-amp-producer-test",
+		Cache:    cache,
+	})
+	r.NoError(err)
+
+	imdsHTTPServer := httptest.NewServer(srv.Handler())
+	defer imdsHTTPServer.Close()
+
+	// 7. Use the real AWS SDK IMDS client to fetch credentials from our server.
+	imdsClient := imds.New(imds.Options{Endpoint: imdsHTTPServer.URL})
+
+	// First call: triggers full Okta -> STS round trip.
+	roleOut, err := imdsClient.GetMetadata(context.Background(), &imds.GetMetadataInput{
+		Path: "iam/security-credentials/",
+	})
+	r.NoError(err)
+	roleNameBytes, _ := io.ReadAll(roleOut.Content)
+	roleOut.Content.Close()
+	r.Equal("argus-amp-producer-test", string(roleNameBytes))
+
+	credsOut, err := imdsClient.GetMetadata(context.Background(), &imds.GetMetadataInput{
+		Path: "iam/security-credentials/argus-amp-producer-test",
+	})
+	r.NoError(err)
+	credsBody, _ := io.ReadAll(credsOut.Content)
+	credsOut.Content.Close()
+	r.Contains(string(credsBody), `"AccessKeyId":"AKIA-INTEGRATION-1"`)
+	r.Contains(string(credsBody), `"Code":"Success"`)
+
+	r.Equal(int32(1), oktaCalls.Load(), "exactly 1 Okta token call for first credential fetch")
+	r.Equal(int32(1), stsCalls.Load(), "exactly 1 STS AssumeRole call for first credential fetch")
+
+	// Second call should use cached credentials — no new Okta or STS calls.
+	credsOut2, err := imdsClient.GetMetadata(context.Background(), &imds.GetMetadataInput{
+		Path: "iam/security-credentials/argus-amp-producer-test",
+	})
+	r.NoError(err)
+	_, _ = io.ReadAll(credsOut2.Content)
+	credsOut2.Content.Close()
+
+	r.Equal(int32(1), oktaCalls.Load(), "second IMDS call must hit cached creds (no Okta call)")
+	r.Equal(int32(1), stsCalls.Load(), "second IMDS call must hit cached creds (no STS call)")
+}
+
+// TestIntegration_GracefulShutdown verifies that http.Server.Shutdown drains
+// in-flight requests when the server context is cancelled.
+func TestIntegration_GracefulShutdown(t *testing.T) {
+	r := require.New(t)
+
+	creds := aws.Credentials{
+		AccessKeyID: "x", SecretAccessKey: "y", SessionToken: "z",
+		Expires: time.Now().Add(time.Hour), CanExpire: true,
+	}
+	srv, err := NewServer(Options{
+		RoleName: "argus",
+		Cache:    newTestCache(creds, nil),
+	})
+	r.NoError(err)
+
+	// Use a custom http.Server (not httptest) so we can call Shutdown.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	r.NoError(err)
+
+	httpSrv := &http.Server{Handler: srv.Handler()}
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- httpSrv.Serve(listener)
+	}()
+
+	url := "http://" + listener.Addr().String()
+
+	// Sanity: first request works.
+	resp, err := http.Get(url + healthzPath)
+	r.NoError(err)
+	resp.Body.Close()
+	r.Equal(http.StatusOK, resp.StatusCode)
+
+	// Shutdown.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	r.NoError(httpSrv.Shutdown(shutdownCtx))
+
+	// Wait for Serve to return.
+	select {
+	case err := <-serveErr:
+		// http.ErrServerClosed is the expected signal.
+		r.ErrorIs(err, http.ErrServerClosed)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve did not return after Shutdown")
+	}
+
+	// Subsequent connections should be refused.
+	_, err = http.Get(url + healthzPath)
+	r.Error(err, "post-shutdown requests should fail")
+}

--- a/pkg/imds_server/server.go
+++ b/pkg/imds_server/server.go
@@ -1,0 +1,395 @@
+// Package imds_server implements an IMDSv2-shaped HTTP server that exposes
+// AWS STS credentials on a localhost endpoint. It is wire-compatible with
+// the AWS SDK Go v2 IMDS credential provider so unmodified workloads
+// (Prometheus, AWS CLI, etc.) can fetch credentials by setting
+// AWS_EC2_METADATA_SERVICE_ENDPOINT to the server's URL.
+//
+// The server supports both IMDSv2 (token dance) and IMDSv1 (no header) paths
+// for SDK fallback compatibility. IMDSv1 can be disabled via Options.
+//
+// Sensitive wire-shape requirements verified against the AWS SDK Go v2 source
+// (feature/ec2/imds/, credentials/ec2rolecreds/):
+//   - PUT /latest/api/token MUST include the X-Aws-Ec2-Metadata-Token-Ttl-Seconds
+//     response header. Without it, the SDK errors out and may downgrade to v1.
+//   - The credentials JSON requires Code (case-insensitive "Success"),
+//     AccessKeyId, SecretAccessKey, Token, and Expiration (RFC 3339).
+//     Type and LastUpdated are optional but harmless.
+package imds_server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/handlers"
+)
+
+const (
+	// imdsTokenHeader is the request header that carries the IMDSv2 session
+	// token. (Casing per AWS docs.)
+	imdsTokenHeader = "X-Aws-Ec2-Metadata-Token"
+
+	// imdsTokenTTLHeader is the header used both to request a TTL on PUT and
+	// to confirm the granted TTL on the response. THE RESPONSE HEADER IS
+	// REQUIRED — the SDK errors out if it's missing.
+	imdsTokenTTLHeader = "X-Aws-Ec2-Metadata-Token-Ttl-Seconds"
+
+	// AWS doc default and max TTL.
+	maxIMDSTokenTTLSeconds     = 21600 // 6 hours
+	defaultIMDSTokenTTLSeconds = 21600
+
+	roleCredsPathPrefix = "/latest/meta-data/iam/security-credentials/"
+	roleListPath        = "/latest/meta-data/iam/security-credentials/"
+	tokenPath           = "/latest/api/token"
+	healthzPath         = "/healthz"
+	readyzPath          = "/readyz"
+)
+
+// Options configures Server.
+type Options struct {
+	// RoleName is the role identifier exposed at the IMDS role-list endpoint.
+	// Typically derived from the IAM role's name (e.g. "argus-amp-producer-bruno").
+	RoleName string
+
+	// Cache is the credentials provider used to satisfy IMDS credential GETs.
+	Cache *CredentialsCache
+
+	// RequireIMDSv2, if true, refuses GET requests that do not carry a valid
+	// X-Aws-Ec2-Metadata-Token header. Default: false (IMDSv1 fallback allowed).
+	RequireIMDSv2 bool
+
+	// Logger is the slog logger used for request and error logging. If nil,
+	// slog.Default() is used.
+	Logger *slog.Logger
+}
+
+// Server is the IMDSv2-shaped HTTP server.
+type Server struct {
+	opts Options
+
+	// tokens holds minted IMDSv2 session tokens with their expiry.
+	tokensMu sync.Mutex
+	tokens   map[string]time.Time
+}
+
+// NewServer constructs a Server. RoleName and Cache are required.
+func NewServer(opts Options) (*Server, error) {
+	if opts.RoleName == "" {
+		return nil, errors.New("imds_server: NewServer: RoleName is required")
+	}
+	if opts.Cache == nil {
+		return nil, errors.New("imds_server: NewServer: Cache is required")
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	return &Server{
+		opts:   opts,
+		tokens: map[string]time.Time{},
+	}, nil
+}
+
+// Handler returns an http.Handler ready to attach to an http.Server. The
+// handler wraps a mux with gorilla/handlers.RecoveryHandler so panics produce
+// 500s rather than crashing the process.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenPath, s.handleTokenPUT)
+	// Both the role-list path (with trailing slash) and per-role path are
+	// served from the same prefix.
+	mux.HandleFunc(roleCredsPathPrefix, s.handleCredentials)
+	mux.HandleFunc(healthzPath, s.handleHealthz)
+	mux.HandleFunc(readyzPath, s.handleReadyz)
+
+	recoveryLogger := slogRecoveryLogger{logger: s.opts.Logger}
+	return handlers.RecoveryHandler(
+		handlers.PrintRecoveryStack(true),
+		handlers.RecoveryLogger(recoveryLogger),
+	)(mux)
+}
+
+// handleTokenPUT implements PUT /latest/api/token. It MUST set the response
+// header X-Aws-Ec2-Metadata-Token-Ttl-Seconds; without it, the AWS SDK's IMDS
+// client errors out and may unnecessarily downgrade to IMDSv1.
+func (s *Server) handleTokenPUT(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ttlSeconds := defaultIMDSTokenTTLSeconds
+	if v := r.Header.Get(imdsTokenTTLHeader); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed <= 0 {
+			http.Error(w, "bad token ttl", http.StatusBadRequest)
+			return
+		}
+		if parsed > maxIMDSTokenTTLSeconds {
+			parsed = maxIMDSTokenTTLSeconds
+		}
+		ttlSeconds = parsed
+	}
+
+	token, err := mintToken()
+	if err != nil {
+		s.opts.Logger.Error("imds_server: failed to mint token", slog.String("error", err.Error()))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	s.tokensMu.Lock()
+	s.tokens[token] = time.Now().Add(time.Duration(ttlSeconds) * time.Second)
+	// Opportunistic cleanup of expired tokens (keep map small).
+	now := time.Now()
+	for tok, exp := range s.tokens {
+		if exp.Before(now) {
+			delete(s.tokens, tok)
+		}
+	}
+	s.tokensMu.Unlock()
+
+	w.Header().Set(imdsTokenTTLHeader, strconv.Itoa(ttlSeconds))
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(token))
+}
+
+// validToken returns true if the given token is in the minted-token map and
+// not expired.
+func (s *Server) validToken(token string) bool {
+	if token == "" {
+		return false
+	}
+	s.tokensMu.Lock()
+	defer s.tokensMu.Unlock()
+	exp, ok := s.tokens[token]
+	if !ok {
+		return false
+	}
+	if exp.Before(time.Now()) {
+		delete(s.tokens, token)
+		return false
+	}
+	return true
+}
+
+// handleCredentials handles both:
+//   GET /latest/meta-data/iam/security-credentials/        -> role name
+//   GET /latest/meta-data/iam/security-credentials/<role>  -> credential JSON
+//
+// IMDSv2 token-header policy:
+//   - If the header is present, it MUST validate; otherwise 401.
+//   - If the header is absent and RequireIMDSv2=false, accept as v1.
+//   - If the header is absent and RequireIMDSv2=true, 401.
+func (s *Server) handleCredentials(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	tokenHeader := r.Header.Get(imdsTokenHeader)
+	if tokenHeader != "" {
+		if !s.validToken(tokenHeader) {
+			http.Error(w, "invalid IMDSv2 token", http.StatusUnauthorized)
+			return
+		}
+	} else if s.opts.RequireIMDSv2 {
+		http.Error(w, "IMDSv2 token required", http.StatusUnauthorized)
+		return
+	}
+
+	switch r.URL.Path {
+	case roleListPath:
+		// Return the role name as plain text.
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(s.opts.RoleName))
+		return
+
+	case roleCredsPathPrefix + s.opts.RoleName:
+		s.writeCredentials(w, r)
+		return
+
+	default:
+		// Unknown role name; mimic real EC2 IMDS by returning 404.
+		http.NotFound(w, r)
+		return
+	}
+}
+
+// credentialsResponse is the JSON shape EC2 IMDS returns for credential GETs.
+// Required by the AWS SDK: Code, AccessKeyId, SecretAccessKey, Token, Expiration.
+// Type and LastUpdated are optional but conventional.
+type credentialsResponse struct {
+	Code            string `json:"Code"`
+	Type            string `json:"Type,omitempty"`
+	AccessKeyId     string `json:"AccessKeyId,omitempty"`
+	SecretAccessKey string `json:"SecretAccessKey,omitempty"`
+	Token           string `json:"Token,omitempty"`
+	Expiration      string `json:"Expiration,omitempty"`
+	LastUpdated     string `json:"LastUpdated,omitempty"`
+	Message         string `json:"Message,omitempty"`
+}
+
+// writeCredentials writes the IMDS-shaped credentials JSON. On refresh
+// failure, returns HTTP 500 with Code = "AssumeRoleUnauthorizedAccess".
+func (s *Server) writeCredentials(w http.ResponseWriter, r *http.Request) {
+	creds, err := s.opts.Cache.Get(r.Context())
+	now := time.Now().UTC().Format(time.RFC3339)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		s.opts.Logger.Error("imds_server: credential refresh failed",
+			slog.String("error", redactSecretsInError(err)),
+		)
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(credentialsResponse{
+			Code:        "AssumeRoleUnauthorizedAccess",
+			Message:     redactSecretsInError(err),
+			LastUpdated: now,
+		})
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(credentialsResponse{
+		Code:            "Success",
+		Type:            "AWS-HMAC",
+		AccessKeyId:     creds.AccessKeyID,
+		SecretAccessKey: creds.SecretAccessKey,
+		Token:           creds.SessionToken,
+		// AWS SDK Go v2 requires RFC 3339; other formats are rejected.
+		Expiration:  creds.Expires.UTC().Format(time.RFC3339),
+		LastUpdated: now,
+	})
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func (s *Server) handleReadyz(w http.ResponseWriter, _ *http.Request) {
+	if !s.opts.Cache.Ready() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("not ready"))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ready"))
+}
+
+// mintToken generates a 32-byte random hex string for use as an IMDSv2 session token.
+func mintToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("crypto/rand: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// redactSecretsInError defensively scrubs any AWS access key or secret-looking
+// substrings from an error string before logging or returning it. The cache
+// path generally does not surface secrets in errors, but this is belt-and-
+// suspenders to avoid leaking the JWT or STS credentials in IMDS error bodies.
+func redactSecretsInError(err error) string {
+	if err == nil {
+		return ""
+	}
+	s := err.Error()
+	// Strip what looks like a JWT (three base64 segments separated by dots).
+	// JWTs are long; replace anything 40+ chars with no spaces matching the
+	// charset.
+	s = jwtPattern.ReplaceAllString(s, "[REDACTED-JWT]")
+	return s
+}
+
+// jwtPattern matches JWT-like substrings: three base64url segments separated
+// by dots. The minimum length of 40 chars is just a heuristic to avoid
+// accidentally matching short tokens.
+var jwtPattern = mustCompileJWTPattern()
+
+func mustCompileJWTPattern() *jwtRegexp {
+	return &jwtRegexp{}
+}
+
+// jwtRegexp is a minimal regexp wrapper. We avoid pulling in the full regexp
+// package for one pattern by implementing a small ad-hoc matcher: anything
+// containing two `.` characters with sufficiently long base64-ish chunks
+// either side. Returns input verbatim if no match.
+type jwtRegexp struct{}
+
+func (j *jwtRegexp) ReplaceAllString(s, replacement string) string {
+	// Find runs of base64url chars (A-Za-z0-9-_) that contain at least two dots.
+	var b strings.Builder
+	for {
+		start, end := findJWTSpan(s)
+		if start < 0 {
+			b.WriteString(s)
+			break
+		}
+		b.WriteString(s[:start])
+		b.WriteString(replacement)
+		s = s[end:]
+	}
+	return b.String()
+}
+
+func findJWTSpan(s string) (int, int) {
+	// Scan for a run of [A-Za-z0-9-_.] of length >= 40 with exactly two dots.
+	const minLen = 40
+	for i := 0; i < len(s); i++ {
+		if !isJWTChar(s[i]) {
+			continue
+		}
+		j := i
+		dots := 0
+		for j < len(s) && isJWTChar(s[j]) {
+			if s[j] == '.' {
+				dots++
+			}
+			j++
+		}
+		if j-i >= minLen && dots == 2 {
+			return i, j
+		}
+		i = j
+	}
+	return -1, -1
+}
+
+func isJWTChar(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	case c == '-', c == '_', c == '.':
+		return true
+	}
+	return false
+}
+
+// slogRecoveryLogger adapts slog.Logger to the gorilla/handlers
+// RecoveryLogger interface (which expects a Println(args ...interface{})
+// method). Mirrors the existing pkg/aws_config_server pattern.
+type slogRecoveryLogger struct {
+	logger *slog.Logger
+}
+
+func (l slogRecoveryLogger) Println(args ...interface{}) {
+	l.logger.Error("imds_server: panic recovered", slog.Any("args", args))
+}
+
+// Reference errors and fmt to keep them used unambiguously where they appear
+// (errors.New / fmt.Errorf in handlers above).
+var _ = errors.New
+var _ = fmt.Errorf

--- a/pkg/imds_server/server_test.go
+++ b/pkg/imds_server/server_test.go
@@ -1,0 +1,412 @@
+package imds_server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/stretchr/testify/require"
+)
+
+// dummyCache is a CredentialsCache stand-in for tests that need to control
+// the credential value or simulate an error.
+func dummyCache(t *testing.T, creds aws.Credentials, retrieveErr error) *CredentialsCache {
+	t.Helper()
+	return newTestCache(creds, retrieveErr)
+}
+
+// newTestCache builds a CredentialsCache that returns the given credentials
+// or error on Get. It bypasses the real STS provider.
+func newTestCache(creds aws.Credentials, retrieveErr error) *CredentialsCache {
+	c := &CredentialsCache{}
+	c.inner = stubProvider{creds: creds, err: retrieveErr}
+	return c
+}
+
+type stubProvider struct {
+	creds aws.Credentials
+	err   error
+}
+
+func (s stubProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+	return s.creds, s.err
+}
+
+func startServer(t *testing.T, opts Options) *httptest.Server {
+	t.Helper()
+	srv, err := NewServer(opts)
+	require.NoError(t, err)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestServer_RequiresRoleNameAndCache(t *testing.T) {
+	r := require.New(t)
+	_, err := NewServer(Options{})
+	r.Error(err)
+	r.Contains(err.Error(), "RoleName")
+
+	_, err = NewServer(Options{RoleName: "x"})
+	r.Error(err)
+	r.Contains(err.Error(), "Cache")
+}
+
+func TestPUT_TokenIncludesTTLHeader(t *testing.T) {
+	r := require.New(t)
+	creds := aws.Credentials{
+		AccessKeyID:     "AKIA1",
+		SecretAccessKey: "secret",
+		SessionToken:    "token",
+		Expires:         time.Now().Add(time.Hour),
+		CanExpire:       true,
+	}
+	ts := startServer(t, Options{
+		RoleName: "argus-amp-producer-test",
+		Cache:    dummyCache(t, creds, nil),
+	})
+
+	req, err := http.NewRequest(http.MethodPut, ts.URL+tokenPath, nil)
+	r.NoError(err)
+	req.Header.Set(imdsTokenTTLHeader, "60")
+
+	resp, err := http.DefaultClient.Do(req)
+	r.NoError(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusOK, resp.StatusCode)
+
+	// Critical: the response MUST include the TTL header.
+	r.NotEmpty(resp.Header.Get(imdsTokenTTLHeader),
+		"PUT /latest/api/token must include X-Aws-Ec2-Metadata-Token-Ttl-Seconds response header; SDK errors without it")
+	r.Equal("60", resp.Header.Get(imdsTokenTTLHeader))
+
+	body, err := io.ReadAll(resp.Body)
+	r.NoError(err)
+	r.NotEmpty(body, "token body should be non-empty")
+	r.Len(string(body), 64, "32-byte hex token should be 64 chars")
+}
+
+func TestPUT_TokenInvalidTTL(t *testing.T) {
+	r := require.New(t)
+	ts := startServer(t, Options{
+		RoleName: "argus",
+		Cache:    dummyCache(t, aws.Credentials{}, nil),
+	})
+
+	req, err := http.NewRequest(http.MethodPut, ts.URL+tokenPath, nil)
+	r.NoError(err)
+	req.Header.Set(imdsTokenTTLHeader, "abc")
+	resp, err := http.DefaultClient.Do(req)
+	r.NoError(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestPUT_TokenWithoutTTL_UsesDefault(t *testing.T) {
+	r := require.New(t)
+	ts := startServer(t, Options{
+		RoleName: "argus",
+		Cache:    dummyCache(t, aws.Credentials{}, nil),
+	})
+
+	req, err := http.NewRequest(http.MethodPut, ts.URL+tokenPath, nil)
+	r.NoError(err)
+	resp, err := http.DefaultClient.Do(req)
+	r.NoError(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusOK, resp.StatusCode)
+	r.Equal("21600", resp.Header.Get(imdsTokenTTLHeader))
+}
+
+func TestGET_RoleListAndCredentials_V2Flow(t *testing.T) {
+	r := require.New(t)
+	creds := aws.Credentials{
+		AccessKeyID:     "AKIA-TEST",
+		SecretAccessKey: "secret-test",
+		SessionToken:    "token-test",
+		Expires:         time.Now().Add(time.Hour),
+		CanExpire:       true,
+	}
+	ts := startServer(t, Options{
+		RoleName: "argus-test-role",
+		Cache:    dummyCache(t, creds, nil),
+	})
+
+	// 1. PUT to mint a v2 session token.
+	req, err := http.NewRequest(http.MethodPut, ts.URL+tokenPath, nil)
+	r.NoError(err)
+	req.Header.Set(imdsTokenTTLHeader, "300")
+	resp, err := http.DefaultClient.Do(req)
+	r.NoError(err)
+	tokenBody, err := io.ReadAll(resp.Body)
+	r.NoError(err)
+	resp.Body.Close()
+	imdsTok := string(tokenBody)
+	r.NotEmpty(imdsTok)
+
+	// 2. GET role list with the token.
+	req, err = http.NewRequest(http.MethodGet, ts.URL+roleListPath, nil)
+	r.NoError(err)
+	req.Header.Set(imdsTokenHeader, imdsTok)
+	resp, err = http.DefaultClient.Do(req)
+	r.NoError(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	r.NoError(err)
+	r.Equal("argus-test-role", string(body))
+
+	// 3. GET credentials.
+	req, err = http.NewRequest(http.MethodGet, ts.URL+roleCredsPathPrefix+"argus-test-role", nil)
+	r.NoError(err)
+	req.Header.Set(imdsTokenHeader, imdsTok)
+	resp, err = http.DefaultClient.Do(req)
+	r.NoError(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusOK, resp.StatusCode)
+	body, err = io.ReadAll(resp.Body)
+	r.NoError(err)
+	bodyStr := string(body)
+	r.Contains(bodyStr, `"Code":"Success"`)
+	r.Contains(bodyStr, `"AccessKeyId":"AKIA-TEST"`)
+	r.Contains(bodyStr, `"SecretAccessKey":"secret-test"`)
+	r.Contains(bodyStr, `"Token":"token-test"`)
+	r.Contains(bodyStr, `"Expiration":"`)
+	// Expiration must be RFC 3339 — the AWS SDK rejects other formats.
+	expField := extractField(bodyStr, "Expiration")
+	_, err = time.Parse(time.RFC3339, expField)
+	r.NoError(err, "Expiration must parse as RFC 3339 (got %q)", expField)
+}
+
+func TestGET_Credentials_V1Flow_NoToken(t *testing.T) {
+	r := require.New(t)
+	creds := aws.Credentials{
+		AccessKeyID:     "AKIA-V1",
+		SecretAccessKey: "secret",
+		SessionToken:    "token",
+		Expires:         time.Now().Add(time.Hour),
+		CanExpire:       true,
+	}
+	ts := startServer(t, Options{
+		RoleName: "argus",
+		Cache:    dummyCache(t, creds, nil),
+	})
+
+	resp, err := http.Get(ts.URL + roleCredsPathPrefix + "argus")
+	r.NoError(err)
+	defer resp.Body.Close()
+	// Default RequireIMDSv2=false: v1 path accepted.
+	r.Equal(http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	r.Contains(string(body), `"Code":"Success"`)
+}
+
+func TestGET_Credentials_RequireIMDSv2_Refuses_V1(t *testing.T) {
+	r := require.New(t)
+	ts := startServer(t, Options{
+		RoleName:      "argus",
+		Cache:         dummyCache(t, aws.Credentials{}, nil),
+		RequireIMDSv2: true,
+	})
+
+	resp, err := http.Get(ts.URL + roleCredsPathPrefix + "argus")
+	r.NoError(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestGET_Credentials_V2_InvalidToken_401(t *testing.T) {
+	r := require.New(t)
+	ts := startServer(t, Options{
+		RoleName: "argus",
+		Cache:    dummyCache(t, aws.Credentials{}, nil),
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+roleCredsPathPrefix+"argus", nil)
+	req.Header.Set(imdsTokenHeader, "not-a-real-token")
+	resp, err := http.DefaultClient.Do(req)
+	r.NoError(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestGET_Credentials_RefreshFailure_500(t *testing.T) {
+	r := require.New(t)
+	ts := startServer(t, Options{
+		RoleName: "argus",
+		Cache:    dummyCache(t, aws.Credentials{}, errors.New("okta unreachable")),
+	})
+
+	resp, err := http.Get(ts.URL + roleCredsPathPrefix + "argus")
+	r.NoError(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusInternalServerError, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	r.Contains(string(body), `"Code":"AssumeRoleUnauthorizedAccess"`)
+	r.Contains(string(body), "okta unreachable")
+}
+
+func TestGET_UnknownRole_404(t *testing.T) {
+	r := require.New(t)
+	ts := startServer(t, Options{
+		RoleName: "argus",
+		Cache:    dummyCache(t, aws.Credentials{}, nil),
+	})
+
+	resp, err := http.Get(ts.URL + roleCredsPathPrefix + "wrong-role")
+	r.NoError(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusNotFound, resp.StatusCode)
+}
+
+func TestHealthAndReady(t *testing.T) {
+	r := require.New(t)
+	cache := dummyCache(t, aws.Credentials{
+		AccessKeyID: "x", SecretAccessKey: "y", SessionToken: "z",
+		Expires: time.Now().Add(time.Hour), CanExpire: true,
+	}, nil)
+	ts := startServer(t, Options{
+		RoleName: "argus",
+		Cache:    cache,
+	})
+
+	// /healthz always 200
+	resp, err := http.Get(ts.URL + healthzPath)
+	r.NoError(err)
+	resp.Body.Close()
+	r.Equal(http.StatusOK, resp.StatusCode)
+
+	// /readyz starts unready
+	resp, err = http.Get(ts.URL + readyzPath)
+	r.NoError(err)
+	resp.Body.Close()
+	r.Equal(http.StatusServiceUnavailable, resp.StatusCode)
+
+	// After one successful Get, ready
+	_, err = cache.Get(context.Background())
+	r.NoError(err)
+	resp, err = http.Get(ts.URL + readyzPath)
+	r.NoError(err)
+	resp.Body.Close()
+	r.Equal(http.StatusOK, resp.StatusCode)
+}
+
+// TestSDKCompatibility_V2 verifies the AWS SDK Go v2's IMDS provider can
+// successfully fetch credentials from our server using the v2 token dance.
+// This is the most important regression test: any wire-shape mistake here
+// breaks the whole point of the helper.
+func TestSDKCompatibility_V2(t *testing.T) {
+	r := require.New(t)
+	want := aws.Credentials{
+		AccessKeyID:     "AKIA-SDKTEST",
+		SecretAccessKey: "secret-sdktest",
+		SessionToken:    "token-sdktest",
+		Expires:         time.Now().Add(30 * time.Minute).UTC(),
+		CanExpire:       true,
+	}
+	ts := startServer(t, Options{
+		RoleName: "argus-sdktest",
+		Cache:    dummyCache(t, want, nil),
+	})
+
+	// Build an IMDS client pointed at our server.
+	client := imds.New(imds.Options{
+		Endpoint: ts.URL,
+	})
+
+	// First, the SDK fetches the role name…
+	roleOut, err := client.GetMetadata(context.Background(), &imds.GetMetadataInput{
+		Path: "iam/security-credentials/",
+	})
+	r.NoError(err)
+	defer roleOut.Content.Close()
+	roleNameBytes, err := io.ReadAll(roleOut.Content)
+	r.NoError(err)
+	r.Equal("argus-sdktest", string(roleNameBytes))
+
+	// …then per-role credentials.
+	credsOut, err := client.GetMetadata(context.Background(), &imds.GetMetadataInput{
+		Path: "iam/security-credentials/argus-sdktest",
+	})
+	r.NoError(err)
+	defer credsOut.Content.Close()
+	credsBody, err := io.ReadAll(credsOut.Content)
+	r.NoError(err)
+	r.Contains(string(credsBody), `"Code":"Success"`)
+	r.Contains(string(credsBody), `"AccessKeyId":"AKIA-SDKTEST"`)
+}
+
+// TestSDKCompatibility_V1Fallback verifies that when our server doesn't require
+// v2, the v1 path (no token header) still works for the SDK.
+func TestSDKCompatibility_V1Fallback(t *testing.T) {
+	r := require.New(t)
+	want := aws.Credentials{
+		AccessKeyID:     "AKIA-V1",
+		SecretAccessKey: "secret",
+		SessionToken:    "token",
+		Expires:         time.Now().Add(30 * time.Minute).UTC(),
+		CanExpire:       true,
+	}
+	ts := startServer(t, Options{
+		RoleName: "argus-v1",
+		Cache:    dummyCache(t, want, nil),
+	})
+
+	// We test the v1 path manually since the SDK starts with v2.
+	resp, err := http.Get(ts.URL + roleCredsPathPrefix + "argus-v1")
+	r.NoError(err)
+	defer resp.Body.Close()
+	r.Equal(http.StatusOK, resp.StatusCode)
+}
+
+// TestRedactSecretsInError verifies the JWT redaction helper.
+func TestRedactSecretsInError(t *testing.T) {
+	cases := map[string]struct {
+		in       string
+		notWant  string
+		want     string
+	}{
+		"plain string": {
+			in:   "okta unreachable",
+			want: "okta unreachable",
+		},
+		"jwt is redacted": {
+			in:      "got token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwb2Ex.signaturepart_with_enough_chars and other text",
+			notWant: "eyJhbGciOiJIUzI1NiJ9",
+			want:    "[REDACTED-JWT]",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			got := redactSecretsInError(errors.New(tc.in))
+			if tc.notWant != "" {
+				r.NotContains(got, tc.notWant)
+			}
+			r.Contains(got, tc.want)
+		})
+	}
+}
+
+// extractField pulls a string-typed JSON field value out of a flat JSON
+// object body. Best-effort; sufficient for asserting on Expiration etc.
+func extractField(body, field string) string {
+	prefix := `"` + field + `":"`
+	i := strings.Index(body, prefix)
+	if i < 0 {
+		return ""
+	}
+	rest := body[i+len(prefix):]
+	end := strings.IndexByte(rest, '"')
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}

--- a/pkg/workload_oidc/client_credentials.go
+++ b/pkg/workload_oidc/client_credentials.go
@@ -1,0 +1,158 @@
+package workload_oidc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+const (
+	defaultMaxAttempts  = 3
+	defaultInitialDelay = 500 * time.Millisecond
+	defaultMaxDelay     = 5 * time.Second
+)
+
+// FetchToken performs an OAuth 2.0 client_credentials grant against the
+// configured Custom Authorization Server and returns the issued access_token
+// JWT. The token's Expiry is also returned for the caller to inform any
+// downstream credential cache.
+//
+// FetchToken sends client credentials in the request body (client_secret_post,
+// equivalent to oauth2.AuthStyleInParams). It does NOT send an `audience`
+// parameter — Okta auto-stamps the `aud` claim from its Custom AS
+// configuration.
+//
+// FetchToken retries up to defaultMaxAttempts times with exponential backoff
+// on transient failures (HTTP 5xx, network errors). 4xx responses are treated
+// as permanent configuration errors and not retried.
+func (c Config) FetchToken(ctx context.Context) (jwt string, expiresAt time.Time, err error) {
+	if err := c.validate(); err != nil {
+		return "", time.Time{}, err
+	}
+
+	tokenURL := strings.TrimRight(c.IssuerURL, "/") + "/v1/token"
+
+	cfg := &clientcredentials.Config{
+		ClientID:     c.ClientID,
+		ClientSecret: c.ClientSecret,
+		TokenURL:     tokenURL,
+		Scopes:       c.Scopes,
+		AuthStyle:    oauth2.AuthStyleInParams,
+	}
+
+	var token *oauth2.Token
+	err = retryWithBackoff(ctx, defaultMaxAttempts, func(ctx context.Context) error {
+		tok, tokErr := cfg.Token(ctx)
+		if tokErr != nil {
+			return tokErr
+		}
+		token = tok
+		return nil
+	})
+	if err != nil {
+		return "", time.Time{}, classifyTokenError(err)
+	}
+	if token == nil || token.AccessToken == "" {
+		return "", time.Time{}, ErrTokenMissing
+	}
+
+	return token.AccessToken, token.Expiry, nil
+}
+
+func (c Config) validate() error {
+	if c.ClientID == "" {
+		return fmt.Errorf("workload_oidc: %w: ClientID is empty", ErrInvalidClient)
+	}
+	if c.ClientSecret == "" {
+		return fmt.Errorf("workload_oidc: %w: ClientSecret is empty", ErrInvalidClient)
+	}
+	if c.IssuerURL == "" {
+		return fmt.Errorf("workload_oidc: %w: IssuerURL is empty", ErrIssuerUnreachable)
+	}
+	if !strings.HasPrefix(c.IssuerURL, "https://") && !strings.HasPrefix(c.IssuerURL, "http://") {
+		return fmt.Errorf("workload_oidc: %w: IssuerURL must start with http:// or https://", ErrIssuerUnreachable)
+	}
+	return nil
+}
+
+// classifyTokenError converts oauth2 errors into the package's sentinel errors
+// where appropriate. 401/403 from the issuer becomes ErrInvalidClient.
+func classifyTokenError(err error) error {
+	var oauthErr *oauth2.RetrieveError
+	if errors.As(err, &oauthErr) && oauthErr.Response != nil {
+		switch oauthErr.Response.StatusCode {
+		case 401, 403:
+			return fmt.Errorf("workload_oidc: %w: %v", ErrInvalidClient, err)
+		}
+	}
+	return fmt.Errorf("workload_oidc: token request failed: %w", err)
+}
+
+// retryWithBackoff retries a function up to maxAttempts times with exponential
+// backoff and jitter. Only transient errors trigger a retry — see
+// isTransientError for the classification.
+func retryWithBackoff(ctx context.Context, maxAttempts int, fn func(ctx context.Context) error) error {
+	var lastErr error
+	delay := defaultInitialDelay
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err := fn(ctx)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		if !isTransientError(err) {
+			return err
+		}
+		if attempt == maxAttempts {
+			break
+		}
+
+		// Jittered exponential backoff: between 50% and 100% of the delay.
+		jittered := delay/2 + time.Duration(rand.Int64N(int64(delay/2)+1))
+		slog.Debug("workload_oidc: transient error, retrying",
+			slog.Int("attempt", attempt),
+			slog.Duration("backoff", jittered),
+			slog.String("error", err.Error()),
+		)
+		select {
+		case <-time.After(jittered):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		delay *= 2
+		if delay > defaultMaxDelay {
+			delay = defaultMaxDelay
+		}
+	}
+	return fmt.Errorf("retry exhausted after %d attempts: %w", maxAttempts, lastErr)
+}
+
+// isTransientError returns true for errors that are likely to succeed on
+// retry: HTTP 5xx from the issuer, and network-layer errors. HTTP 4xx
+// responses are treated as permanent configuration errors and not retried.
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var oauthErr *oauth2.RetrieveError
+	if errors.As(err, &oauthErr) {
+		if oauthErr.Response != nil {
+			return oauthErr.Response.StatusCode >= 500
+		}
+		// No HTTP response attached: assume transport-level failure → retryable.
+		return true
+	}
+	// Anything else (DNS, TLS, connection refused, EOF) is transient.
+	return true
+}

--- a/pkg/workload_oidc/client_credentials_test.go
+++ b/pkg/workload_oidc/client_credentials_test.go
@@ -1,0 +1,320 @@
+package workload_oidc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+	Scope       string `json:"scope,omitempty"`
+}
+
+func TestFetchToken_HappyPath(t *testing.T) {
+	r := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal("/v1/token", req.URL.Path)
+		r.Equal(http.MethodPost, req.Method)
+		r.NoError(req.ParseForm())
+		r.Equal("client_credentials", req.Form.Get("grant_type"))
+		// AuthStyleInParams puts client_id and client_secret in the body.
+		r.Equal("test-client", req.Form.Get("client_id"))
+		r.Equal("test-secret", req.Form.Get("client_secret"))
+		r.Equal("aws-m2m-access", req.Form.Get("scope"))
+		// We must NOT send an audience parameter — that's an Auth0-ism.
+		r.Empty(req.Form.Get("audience"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockTokenResponse{
+			AccessToken: "fake.jwt.token",
+			ExpiresIn:   3600,
+			TokenType:   "Bearer",
+			Scope:       "aws-m2m-access",
+		})
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		IssuerURL:    server.URL,
+		Scopes:       []string{"aws-m2m-access"},
+	}
+
+	jwt, expiresAt, err := cfg.FetchToken(context.Background())
+	r.NoError(err)
+	r.Equal("fake.jwt.token", jwt)
+	r.WithinDuration(time.Now().Add(time.Hour), expiresAt, 5*time.Second)
+}
+
+func TestFetchToken_BadCredentials_NoRetry(t *testing.T) {
+	r := require.New(t)
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"error":"invalid_client","error_description":"Client authentication failed."}`)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ClientID:     "bad",
+		ClientSecret: "wrong",
+		IssuerURL:    server.URL,
+	}
+
+	_, _, err := cfg.FetchToken(context.Background())
+	r.Error(err)
+	r.True(errors.Is(err, ErrInvalidClient), "expected ErrInvalidClient, got %v", err)
+	// 4xx must NOT trigger retries — exactly one call.
+	r.Equal(int32(1), calls.Load(), "401 should not be retried")
+}
+
+func TestFetchToken_TransientThenSuccess_Retries(t *testing.T) {
+	r := require.New(t)
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		n := calls.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = fmt.Fprint(w, `{"error":"server_error"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockTokenResponse{
+			AccessToken: "after.retry.jwt",
+			ExpiresIn:   3600,
+			TokenType:   "Bearer",
+		})
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		IssuerURL:    server.URL,
+	}
+
+	jwt, _, err := cfg.FetchToken(context.Background())
+	r.NoError(err)
+	r.Equal("after.retry.jwt", jwt)
+	r.Equal(int32(3), calls.Load())
+}
+
+func TestFetchToken_Persistent5xx_RetriesExhausted(t *testing.T) {
+	r := require.New(t)
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		IssuerURL:    server.URL,
+	}
+
+	_, _, err := cfg.FetchToken(context.Background())
+	r.Error(err)
+	r.Equal(int32(defaultMaxAttempts), calls.Load(), "should attempt all retries on persistent 5xx")
+}
+
+func TestFetchToken_NetworkError_Retries(t *testing.T) {
+	r := require.New(t)
+
+	// Bind a port, close immediately so connect refuses.
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	cfg := Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		IssuerURL:    url,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, _, err := cfg.FetchToken(ctx)
+	r.Error(err, "expected error from refused connection")
+}
+
+func TestFetchToken_MalformedJSON(t *testing.T) {
+	r := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{not-json}`)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		IssuerURL:    server.URL,
+	}
+
+	_, _, err := cfg.FetchToken(context.Background())
+	r.Error(err)
+}
+
+func TestFetchToken_MissingAccessToken(t *testing.T) {
+	r := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// 200 with empty body / no access_token field.
+		_, _ = fmt.Fprint(w, `{"token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		IssuerURL:    server.URL,
+	}
+
+	_, _, err := cfg.FetchToken(context.Background())
+	r.Error(err)
+}
+
+func TestFetchToken_ContextCanceled_NoRetry(t *testing.T) {
+	r := require.New(t)
+
+	var calls atomic.Int32
+	cleanup := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		calls.Add(1)
+		// Block until either the client disconnects or test cleanup signals.
+		// We use cleanup so server.Close() never blocks even if the client
+		// disconnect doesn't promptly cancel req.Context().
+		select {
+		case <-req.Context().Done():
+		case <-cleanup:
+		}
+	}))
+	defer func() {
+		close(cleanup)
+		server.Close()
+	}()
+
+	cfg := Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		IssuerURL:    server.URL,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, _, err := cfg.FetchToken(ctx)
+	r.Error(err)
+	// Context cancellation must not retry.
+	r.LessOrEqual(calls.Load(), int32(1), "context cancellation should not retry")
+}
+
+func TestValidate(t *testing.T) {
+	cases := map[string]struct {
+		cfg     Config
+		wantErr error
+	}{
+		"missing client_id": {
+			cfg:     Config{ClientSecret: "x", IssuerURL: "https://example.okta.com/oauth2/aus123"},
+			wantErr: ErrInvalidClient,
+		},
+		"missing client_secret": {
+			cfg:     Config{ClientID: "x", IssuerURL: "https://example.okta.com/oauth2/aus123"},
+			wantErr: ErrInvalidClient,
+		},
+		"missing issuer_url": {
+			cfg:     Config{ClientID: "x", ClientSecret: "x"},
+			wantErr: ErrIssuerUnreachable,
+		},
+		"non-http issuer_url": {
+			cfg:     Config{ClientID: "x", ClientSecret: "x", IssuerURL: "ftp://example.com"},
+			wantErr: ErrIssuerUnreachable,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			err := tc.cfg.validate()
+			r.Error(err)
+			r.True(errors.Is(err, tc.wantErr), "expected %v, got %v", tc.wantErr, err)
+		})
+	}
+}
+
+func TestConfig_RedactsSecret(t *testing.T) {
+	r := require.New(t)
+
+	cfg := Config{
+		ClientID:     "client-id",
+		ClientSecret: "super-secret-value",
+		IssuerURL:    "https://example.okta.com/oauth2/aus123",
+		Scopes:       []string{"foo"},
+	}
+
+	// fmt.Stringer
+	got := cfg.String()
+	r.NotContains(got, "super-secret-value")
+	r.Contains(got, "[REDACTED]")
+	r.Contains(got, "client-id")
+
+	// %v / %+v formatters use Stringer
+	r.NotContains(fmt.Sprintf("%v", cfg), "super-secret-value")
+	r.NotContains(fmt.Sprintf("%+v", cfg), "super-secret-value")
+
+	// slog LogValue
+	v := cfg.LogValue()
+	rendered := v.String()
+	r.NotContains(rendered, "super-secret-value")
+	r.Contains(rendered, "[REDACTED]")
+}
+
+func TestFetchToken_TrimsTrailingSlashOnIssuerURL(t *testing.T) {
+	r := require.New(t)
+
+	var receivedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		receivedPath = req.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockTokenResponse{
+			AccessToken: "x",
+			ExpiresIn:   3600,
+			TokenType:   "Bearer",
+		})
+	}))
+	defer server.Close()
+
+	// Trailing slash on the issuer URL should not produce a //v1/token URL.
+	cfg := Config{
+		ClientID:     "x",
+		ClientSecret: "x",
+		IssuerURL:    server.URL + "/",
+	}
+	_, _, err := cfg.FetchToken(context.Background())
+	r.NoError(err)
+	r.Equal("/v1/token", receivedPath)
+	r.False(strings.Contains(receivedPath, "//"), "should not produce double-slash path")
+}

--- a/pkg/workload_oidc/types.go
+++ b/pkg/workload_oidc/types.go
@@ -1,0 +1,81 @@
+// Package workload_oidc implements an OAuth 2.0 client_credentials grant
+// against an Okta Custom Authorization Server, intended for unattended
+// (non-human) workloads. The resulting access_token JWT can be exchanged for
+// AWS STS credentials via sts:AssumeRoleWithWebIdentity.
+//
+// IMPORTANT: the IssuerURL on Config MUST point to an Okta Custom Authorization
+// Server (e.g. https://example.okta.com/oauth2/<auth_server_id>). The Okta Org
+// (default) Authorization Server at https://example.okta.com/oauth2/v1 issues
+// opaque access tokens whose structure is "subject to change at any time
+// without notice" per Okta documentation, and AWS STS cannot validate them.
+package workload_oidc
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+)
+
+// Sentinel errors used by the package. Wrap with fmt.Errorf("...: %w", err).
+var (
+	// ErrInvalidClient indicates that the configured client credentials were
+	// rejected by the issuer (HTTP 401 / invalid_client). Generally not
+	// transient — fix the configuration.
+	ErrInvalidClient = errors.New("invalid client credentials")
+
+	// ErrIssuerUnreachable indicates the OIDC issuer URL is missing,
+	// malformed, or unreachable.
+	ErrIssuerUnreachable = errors.New("issuer URL unreachable or invalid")
+
+	// ErrTokenMissing indicates the issuer responded successfully but did not
+	// include an access_token.
+	ErrTokenMissing = errors.New("issuer response did not contain access_token")
+)
+
+// Config holds OAuth 2.0 client_credentials configuration for a workload
+// OIDC flow.
+//
+// Audience is intentionally NOT a field on Config. Okta Custom Authorization
+// Servers stamp the `aud` claim from their own configuration and ignore any
+// audience parameter sent on the /v1/token request — that's an Auth0
+// convention, not an Okta one. The audience must be configured at the Okta
+// Custom AS level and matched in the AWS IAM OIDC identity provider's
+// client_id_list and the IAM role's trust policy.
+type Config struct {
+	// ClientID is the Okta Service app's client_id.
+	ClientID string
+
+	// ClientSecret is the Okta Service app's client secret. Treat as sensitive;
+	// the String() and LogValue() methods on Config redact this field.
+	ClientSecret string
+
+	// IssuerURL is the Okta Custom Authorization Server URL, e.g.
+	// "https://example.okta.com/oauth2/aus123abc". The /v1/token suffix is
+	// appended internally. Org / default authorization servers MUST NOT be
+	// used here.
+	IssuerURL string
+
+	// Scopes are the OAuth scopes to request. Typically a custom scope
+	// configured on the Okta Custom AS (e.g. "aws-m2m-access"). May be empty.
+	Scopes []string
+}
+
+// String returns a redacted representation of the Config suitable for logs and
+// error messages. The ClientSecret is replaced with "[REDACTED]".
+func (c Config) String() string {
+	return fmt.Sprintf(
+		"workload_oidc.Config{ClientID:%q IssuerURL:%q Scopes:%v ClientSecret:[REDACTED]}",
+		c.ClientID, c.IssuerURL, c.Scopes,
+	)
+}
+
+// LogValue implements slog.LogValuer so structured logs emit a redacted
+// representation. The ClientSecret never appears in any slog output.
+func (c Config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("client_id", c.ClientID),
+		slog.String("issuer_url", c.IssuerURL),
+		slog.Any("scopes", c.Scopes),
+		slog.String("client_secret", "[REDACTED]"),
+	)
+}


### PR DESCRIPTION
Adds a long-lived credential helper that brokers Okta OAuth 2.0 client_credentials into AWS STS credentials and serves them on a localhost endpoint that mimics EC2 IMDSv2. Unmodified AWS-SDK workloads (Prometheus, AWS CLI) discover the endpoint via
AWS_EC2_METADATA_SERVICE_ENDPOINT and SigV4-sign requests transparently — no long-lived AWS access keys on the host.

New packages:
  pkg/workload_oidc — OAuth 2.0 client_credentials grant against an Okta
    Custom Authorization Server. Includes bounded retry on transient
    failures and a redacting Stringer/LogValuer on Config.
  pkg/imds_server  — IMDSv2-shaped HTTP server (with IMDSv1 fallback for
    SDK compatibility), backed by aws.CredentialsCache around
    stscreds.WebIdentityRoleProvider for native pre-expiry refresh and
    concurrent-call coalescing. /healthz and /readyz for K8s probes.

cmd/serve-imds.go wires Cobra flags and AWS_OIDC_IMDS_* env-var fallbacks, validates the client_secret file mode, performs a startup credential fetch (fail-fast), and handles graceful shutdown via SIGTERM/SIGINT.

pkg/getter/aws_creds.go grows AssumeRoleWithJWT for the workload-flow path (the existing GetAWSAssumeIdentity human flow now delegates to it).

Tests: 44 new tests across the three packages, including TestSDKCompatibility_V2 (real AWS SDK Go v2 IMDS client fetches credentials from our server) and TestIntegration_FullPipeline (end-to-end Okta-mock → workload_oidc → STS-mock → cache → IMDS server → SDK).

Important per-tenant verification before deploying: see docs/serve-imds-workload-helper.md "R1 verification recipe" — confirm your Okta Custom AS access_token is acceptable to AWS STS AssumeRoleWithWebIdentity. The Okta Org / default authorization server issues opaque tokens AWS cannot validate; the helper warns at startup if the issuer URL pattern looks like the Org AS.