### PR TITLE
fix(creds-process): default STS region so credential_process works without AWS_REGION

### DIFF
--- a/pkg/getter/aws_creds.go
+++ b/pkg/getter/aws_creds.go
@@ -17,7 +17,13 @@ func GetAWSAssumeIdentity(
 	roleARN string,
 	sessionDuration time.Duration,
 ) (*sts.AssumeRoleWithWebIdentityOutput, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
+	// AssumeRoleWithWebIdentity is a global STS operation; the region only
+	// selects the endpoint. A credential_process subprocess inherits neither the
+	// caller's --region flag nor the profile's region, and the SDK endpoint
+	// resolver rejects an empty region ("Missing Region"), so fall back to
+	// us-east-1 when nothing else resolves one. An explicit AWS_REGION /
+	// AWS_DEFAULT_REGION still takes precedence over this default.
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithDefaultRegion("us-east-1"))
 	if err != nil {
 		return nil, fmt.Errorf("loading AWS config: %w", err)
 	}


### PR DESCRIPTION
## Summary

Running `aws-oidc` as a `credential_process` (and the `env` / `exec` commands) fails to mint credentials whenever `AWS_REGION` and `AWS_DEFAULT_REGION` are unset, erroring with `Missing Region`.

`AssumeRoleWithWebIdentity` is a global STS operation, so the region only selects which endpoint to hit. But the AWS SDK's endpoint resolver still requires *some* region and rejects an empty one. A `credential_process` subprocess inherits neither the caller's `--region` flag nor the profile's region, so it always lands in the empty-region case and fails.

The fix falls back to `us-east-1` via `config.WithDefaultRegion` in `GetAWSAssumeIdentity`, the single chokepoint all three credential paths route through. `WithDefaultRegion` is fallback-only: an explicit `AWS_REGION` / `AWS_DEFAULT_REGION` (or IMDS-resolved region) still takes precedence, so anyone who already has a region in their environment sees no change. It only rescues the empty-region case that the subprocess always falls into.

Verified by building the patched binary and running `creds-process` with `AWS_REGION` and `AWS_DEFAULT_REGION` explicitly unset: it now mints credentials cleanly instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)