### PR TITLE
chore: register argus-docker-build-dispatch workflow

### DIFF
--- a/.github/workflows/argus-docker-build-dispatch.yaml
+++ b/.github/workflows/argus-docker-build-dispatch.yaml
@@ -1,0 +1,30 @@
+name: Argus Docker Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: 'App name from .argus-ci.yaml'
+        required: true
+        type: string
+      images:
+        description: 'Comma-separated image names (empty = all images in the app)'
+        required: false
+        type: string
+      ref:
+        description: 'Git ref to build (defaults to the branch you trigger from)'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.app }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: chanzuckerberg/github-actions/.github/workflows/argus-builder-dispatch.yaml@v6
+    secrets: inherit
+    with:
+      app: ${{ inputs.app }}
+      images: ${{ inputs.images }}
+      ref: ${{ inputs.ref }}


### PR DESCRIPTION
## Summary

Register the `argus-docker-build-dispatch.yaml` workflow on the default branch so GitHub recognizes it for `workflow_dispatch` calls from the Argus CI Orchestrator.

This is a prerequisite for the full CI orchestrator migration PR — the workflow must exist on `main` before the orchestrator can dispatch builds. The workflow is `workflow_dispatch`-only, so it is inert on its own.

## Context

- The full migration PR (coming next) will add `.argus-ci.yaml` and remove the legacy per-event Argus workflows.
- This PR should be merged first so the orchestrator can dispatch builds when the migration PR lands.