### PR TITLE
fix(serve-config): log sub instead of email in ClientIDs error

### DIFF
--- a/pkg/aws_config_server/webserver.go
+++ b/pkg/aws_config_server/webserver.go
@@ -134,7 +134,7 @@ func Index(
 
 		clientIDs, err := okta.GetClientIDs(ctx, *sub, oktaClient)
 		if err != nil {
-			slog.Error(fmt.Sprintf("getting list of ClientIDs for %s", *email), "error", err)
+			slog.Error(fmt.Sprintf("getting list of ClientIDs for sub %s", *sub), "error", err)
 			http.Error(w, fmt.Sprintf("%v:%s", 500, http.StatusText(500)), 500)
 			return
 		}


### PR DESCRIPTION
## Problem

When `okta.GetClientIDs` fails, the server logs `getting list of ClientIDs for <email>`. In practice the `email` claim on the presented ID token is often empty, so the line renders as `getting list of ClientIDs for ` with no identifier. That makes it impossible to tell which user hit the failure, which came up while debugging why a user's AWS profile was missing from `aws-oidc configure`.

The empty email slips through because the handler only guards `email == nil`, never the empty string, and the value is populated solely from the token's `email` claim. Tokens minted without the `email` scope (older client builds, or cached tokens refreshed with their original scopes) carry no email.

## Solution

Log the `sub` instead. The Okta app lookup is already keyed on the `sub` (`GetClientIDs(ctx, *sub, ...)`), and the `sub` is always present on a verified token, so it reliably identifies the user for the next occurrence.

## Impact

Failures in the app-listing path become attributable to a specific Okta user ID. No behavior change beyond the log message.