### PR TITLE
feat(portal): agent-registry portal server, UI, and per-user access dropdown

### DIFF
--- a/.infra/rdev/templates/rbac.yaml
+++ b/.infra/rdev/templates/rbac.yaml
@@ -25,3 +25,38 @@ subjects:
   - kind: ServiceAccount
     name: aws-oidc
     namespace: {{ .Release.Namespace }}
+---
+# The portal reads the rolemap (for entitlements) and reads/writes the agent-registry
+# ConfigMap. The ServiceAccount is created by the stack chart (serviceAccount.create).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: portal
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["rolemap"]
+    verbs: ["get"]
+  # create cannot be restricted by resourceName, so it is its own rule.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["agent-registry"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: portal
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: portal
+subjects:
+  - kind: ServiceAccount
+    name: portal
+    namespace: {{ .Release.Namespace }}

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -3,13 +3,13 @@ stack:
   services:
     aws-oidc:
       image:
-        tag: sha-d7f00ae
+        tag: sha-5ab22a9
     # The agent-registry portal. rdev-only for now: there is no browser login yet, so it
     # is not exposed in prod. Identity comes from PORTAL_DEV_SUB below.
     portal:
       image:
         repository: 533267185808.dkr.ecr.us-west-2.amazonaws.com/core-platform/aws-oidc/aws-oidc
-        tag: sha-d7f00ae
+        tag: sha-5ab22a9
       serviceAccount:
         create: true
         name: portal

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -5,12 +5,10 @@ stack:
       image:
         tag: sha-5ab22a9
       # This rdev stack is for the portal, which owns the stack root path. The config
-      # server is not exercised here, so move its ingress off "/" to avoid a host+path
+      # server is not exercised here, so disable its ingress to avoid a host+path
       # collision with the portal.
       ingress:
-        paths:
-          - path: /config-server
-            pathType: Prefix
+        enabled: false
     # The agent-registry portal. rdev-only for now: there is no browser login yet, so it
     # is not exposed in prod. Identity comes from PORTAL_DEV_SUB below.
     portal:

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -4,3 +4,43 @@ stack:
     aws-oidc:
       image:
         tag: sha-d7f00ae
+    # The agent-registry portal. rdev-only for now: there is no browser login yet, so it
+    # is not exposed in prod. Identity comes from PORTAL_DEV_SUB below.
+    portal:
+      image:
+        repository: 533267185808.dkr.ecr.us-west-2.amazonaws.com/core-platform/aws-oidc/aws-oidc
+        tag: sha-d7f00ae
+      serviceAccount:
+        create: true
+        name: portal
+      resources:
+        limits:
+          cpu: 300m
+          memory: 500Mi
+        requests:
+          cpu: 300m
+          memory: 500Mi
+      args:
+        - serve-portal
+        - -v
+      ingress:
+        paths:
+          - path: /
+            pathType: Prefix
+      livenessProbe:
+        httpGet:
+          path: /health
+      readinessProbe:
+        httpGet:
+          path: /health
+      env:
+        - name: OKTA_CLIENT_ID
+          value: 0oa1be0s0d6KhEAed1t8
+        - name: OKTA_ISSUER_URL
+          value: https://czi.okta.com
+        - name: OKTA_SERVICE_CLIENT_ID
+          value: 0oa18b7m1cb97rFLK1t8
+        # No browser login yet: set this to YOUR Okta user id to act as that user (you are
+        # treated as admin so you can see everything). Without it the portal returns 401.
+        - name: PORTAL_DEV_SUB
+          value: ""

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -43,4 +43,6 @@ stack:
         # No browser login yet: set this to YOUR Okta user id to act as that user (you are
         # treated as admin so you can see everything). Without it the portal returns 401.
         - name: PORTAL_DEV_SUB
-          value: ""
+          value: "00ugbvc7oiheU3Glz1t7"
+        - name: PORTAL_DEV_EMAIL
+          value: "jheath@chanzuckerberg.com"

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -3,7 +3,7 @@ stack:
   services:
     aws-oidc:
       image:
-        tag: sha-5ab22a9
+        tag: sha-9f88fe5
       # This rdev stack is for the portal, which owns the stack root path. The config
       # server is not exercised here, so disable its ingress to avoid a host+path
       # collision with the portal.
@@ -14,7 +14,7 @@ stack:
     portal:
       image:
         repository: 533267185808.dkr.ecr.us-west-2.amazonaws.com/core-platform/aws-oidc/aws-oidc
-        tag: sha-5ab22a9
+        tag: sha-9f88fe5
       serviceAccount:
         create: true
         name: portal

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -4,6 +4,13 @@ stack:
     aws-oidc:
       image:
         tag: sha-5ab22a9
+      # This rdev stack is for the portal, which owns the stack root path. The config
+      # server is not exercised here, so move its ingress off "/" to avoid a host+path
+      # collision with the portal.
+      ingress:
+        paths:
+          - path: /config-server
+            pathType: Prefix
     # The agent-registry portal. rdev-only for now: there is no browser login yet, so it
     # is not exposed in prod. Identity comes from PORTAL_DEV_SUB below.
     portal:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY cmd cmd
 COPY go.mod go.sum main.go ./
 COPY pkg pkg
+COPY internal internal
 
 ARG PLATFORM=arm64
 ARG RELEASE_VERSION

--- a/cmd/serve-portal.go
+++ b/cmd/serve-portal.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/chanzuckerberg/aws-oidc/internal/portal"
+	"github.com/chanzuckerberg/aws-oidc/pkg/configmap"
+	"github.com/chanzuckerberg/aws-oidc/pkg/okta"
+	"github.com/spf13/cobra"
+)
+
+var portalPort int
+
+const (
+	flagAgentConfigMapName = "agent-configmap-name"
+	flagAgentConfigMapKey  = "agent-configmap-key"
+)
+
+func init() {
+	rootCmd.AddCommand(servePortalCmd)
+	servePortalCmd.Flags().IntVar(&portalPort, "web-server-port", 8080, "Port to host the portal on")
+	servePortalCmd.Flags().String(flagConfigMapName, "rolemap", "Name of the ConfigMap to read the rolemap from")
+	servePortalCmd.Flags().String(flagConfigMapKey, "rolemap.yaml", "Key within the ConfigMap that holds the rolemap YAML")
+	servePortalCmd.Flags().String(flagAgentConfigMapName, "agent-registry", "Name of the ConfigMap that stores the agent registry")
+	servePortalCmd.Flags().String(flagAgentConfigMapKey, "agents.yaml", "Key within the agent registry ConfigMap")
+}
+
+var servePortalCmd = &cobra.Command{
+	Use:           "serve-portal",
+	Short:         "aws-oidc serve-portal",
+	Long:          "Start the agent-registry portal: a minimal UI to register agents and grant each a subset of your AWS access.",
+	SilenceErrors: true,
+	RunE:          servePortalRun,
+}
+
+func servePortalRun(cmd *cobra.Command, args []string) error {
+	oktaEnv, err := loadOktaEnv()
+	if err != nil {
+		return err
+	}
+	ctx := cmd.Context()
+
+	oktaAppClient, err := createOktaClientApps(ctx, oktaEnv.ISSUER_URL, oktaEnv.PRIVATE_KEY, oktaEnv.SERVICE_CLIENT_ID)
+	if err != nil {
+		return fmt.Errorf("creating okta client: %w", err)
+	}
+
+	rolemapName, err := cmd.Flags().GetString(flagConfigMapName)
+	if err != nil {
+		return fmt.Errorf("missing configmap-name flag: %w", err)
+	}
+	rolemapKey, err := cmd.Flags().GetString(flagConfigMapKey)
+	if err != nil {
+		return fmt.Errorf("missing configmap-key flag: %w", err)
+	}
+	agentCMName, err := cmd.Flags().GetString(flagAgentConfigMapName)
+	if err != nil {
+		return fmt.Errorf("missing agent-configmap-name flag: %w", err)
+	}
+	agentCMKey, err := cmd.Flags().GetString(flagAgentConfigMapKey)
+	if err != nil {
+		return fmt.Errorf("missing agent-configmap-key flag: %w", err)
+	}
+
+	kubeClient, namespace, err := configmap.NewInClusterClient()
+	if err != nil {
+		return fmt.Errorf("creating in-cluster client: %w", err)
+	}
+
+	// Read the rolemap fresh on each request so entitlements reflect the latest mapping.
+	mappingsProvider := func(ctx context.Context) (okta.OIDCRoleMappingsByKey, error) {
+		mappings, err := configmap.ReadRoleMappings(ctx, kubeClient, namespace, rolemapName, rolemapKey)
+		if err != nil {
+			return nil, err
+		}
+		return mappings.ByClientID(), nil
+	}
+
+	store := portal.NewConfigMapStore(kubeClient, namespace, agentCMName, agentCMKey)
+
+	srv, err := portal.NewServer(portal.Config{
+		Apps:             oktaAppClient,
+		MappingsProvider: mappingsProvider,
+		Store:            store,
+		Identity:         portal.NewIdentityResolver(),
+	})
+	if err != nil {
+		return fmt.Errorf("creating portal server: %w", err)
+	}
+
+	addr := fmt.Sprintf(":%d", portalPort)
+	return http.ListenAndServe(addr, srv.Handler())
+}

--- a/internal/portal/entitlements.go
+++ b/internal/portal/entitlements.go
@@ -1,0 +1,113 @@
+package portal
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+
+	"github.com/chanzuckerberg/aws-oidc/pkg/okta"
+)
+
+// MappingsProvider returns the current rolemap grouped by client ID. It is called per
+// request so entitlements always reflect the latest rolemap.
+type MappingsProvider func(ctx context.Context) (okta.OIDCRoleMappingsByKey, error)
+
+// RoleAccess is a single role the user can assume in an account.
+type RoleAccess struct {
+	RoleARN  string
+	RoleName string
+}
+
+// AccountAccess is the set of roles the user can assume in one account.
+type AccountAccess struct {
+	AccountID    string
+	AccountAlias string
+	Roles        []RoleAccess
+}
+
+// Label is a display name for the account.
+func (a AccountAccess) Label() string {
+	if a.AccountAlias != "" {
+		return a.AccountAlias
+	}
+	return a.AccountID
+}
+
+// Entitlements is everything a user is allowed to grant an agent: the accounts and roles
+// they can already assume. It is the ceiling for any agent the user owns.
+type Entitlements struct {
+	Accounts []AccountAccess
+	allowed  map[string]Grant
+}
+
+// Allows reports whether the user can grant this account plus role, returning the fully
+// populated grant when they can.
+func (e *Entitlements) Allows(accountID, roleARN string) (Grant, bool) {
+	g, ok := e.allowed[accountID+"|"+roleARN]
+	return g, ok
+}
+
+// Empty reports whether the user has no grantable access at all.
+func (e *Entitlements) Empty() bool {
+	return len(e.Accounts) == 0
+}
+
+// ResolveEntitlements computes a user's grantable access. It lists the Okta apps assigned
+// to the user (their client IDs) and looks each up in the rolemap, exactly as the config
+// server does when it builds a human's aws config.
+func ResolveEntitlements(ctx context.Context, sub string, apps okta.AppLister, mappings okta.OIDCRoleMappingsByKey) (*Entitlements, error) {
+	clientIDs, err := okta.GetClientIDs(ctx, sub, apps)
+	if err != nil {
+		return nil, fmt.Errorf("getting client IDs for %s: %w", sub, err)
+	}
+
+	byAccount := map[string]*AccountAccess{}
+	allowed := map[string]Grant{}
+
+	for _, clientID := range clientIDs {
+		for _, m := range mappings[clientID.String()] {
+			key := m.AWSAccountID + "|" + m.AWSRoleARN
+			if _, seen := allowed[key]; seen {
+				continue
+			}
+
+			roleName := roleNameFromARN(m.AWSRoleARN)
+			grant := Grant{
+				AccountID:    m.AWSAccountID,
+				AccountAlias: m.AWSAccountAlias,
+				RoleARN:      m.AWSRoleARN,
+				RoleName:     roleName,
+			}
+			allowed[key] = grant
+
+			acct, ok := byAccount[m.AWSAccountID]
+			if !ok {
+				acct = &AccountAccess{AccountID: m.AWSAccountID, AccountAlias: m.AWSAccountAlias}
+				byAccount[m.AWSAccountID] = acct
+			}
+			acct.Roles = append(acct.Roles, RoleAccess{RoleARN: m.AWSRoleARN, RoleName: roleName})
+		}
+	}
+
+	accounts := make([]AccountAccess, 0, len(byAccount))
+	for _, acct := range byAccount {
+		sort.Slice(acct.Roles, func(i, j int) bool { return acct.Roles[i].RoleName < acct.Roles[j].RoleName })
+		accounts = append(accounts, *acct)
+	}
+	sort.Slice(accounts, func(i, j int) bool { return accounts[i].Label() < accounts[j].Label() })
+
+	return &Entitlements{Accounts: accounts, allowed: allowed}, nil
+}
+
+// roleNameFromARN extracts the role name from a role ARN, mirroring how the config server
+// derives it. It falls back to the raw ARN if parsing fails.
+func roleNameFromARN(roleARN string) string {
+	parsed, err := arn.Parse(roleARN)
+	if err != nil {
+		return roleARN
+	}
+	return strings.TrimPrefix(parsed.Resource, "role/")
+}

--- a/internal/portal/identity.go
+++ b/internal/portal/identity.go
@@ -1,0 +1,87 @@
+package portal
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// User is the authenticated portal user. Sub is the Okta subject (user id) and is what
+// entitlements and agent ownership are keyed on.
+type User struct {
+	Sub   string
+	Email string
+	Admin bool
+}
+
+// errNoIdentity is returned when no authenticated user can be determined.
+var errNoIdentity = errors.New("no authenticated user")
+
+// IdentityResolver extracts the current user from a request. Real Okta browser login is a
+// follow-up; for now identity comes from a dev override (for rdev) or from trusted headers
+// set by an auth proxy in front of the portal.
+type IdentityResolver struct {
+	devSub       string
+	devEmail     string
+	subHeader    string
+	emailHeader  string
+	groupsHeader string
+	adminGroups  map[string]bool
+}
+
+// NewIdentityResolver reads its configuration from the environment:
+//   - PORTAL_DEV_SUB / PORTAL_DEV_EMAIL: hardcode the current user (rdev/dev). When set,
+//     the user is treated as admin so the whole flow can be exercised.
+//   - PORTAL_SUB_HEADER / PORTAL_EMAIL_HEADER / PORTAL_GROUPS_HEADER: headers an auth proxy
+//     injects. Defaults match oauth2-proxy's X-Auth-Request-* headers.
+//   - PORTAL_ADMIN_GROUPS: comma-separated groups that grant the admin view.
+func NewIdentityResolver() *IdentityResolver {
+	return &IdentityResolver{
+		devSub:       os.Getenv("PORTAL_DEV_SUB"),
+		devEmail:     os.Getenv("PORTAL_DEV_EMAIL"),
+		subHeader:    envOr("PORTAL_SUB_HEADER", "X-Auth-Request-User"),
+		emailHeader:  envOr("PORTAL_EMAIL_HEADER", "X-Auth-Request-Email"),
+		groupsHeader: envOr("PORTAL_GROUPS_HEADER", "X-Auth-Request-Groups"),
+		adminGroups:  parseAdminGroups(os.Getenv("PORTAL_ADMIN_GROUPS")),
+	}
+}
+
+// Resolve returns the current user, or errNoIdentity if none can be determined.
+func (ir *IdentityResolver) Resolve(r *http.Request) (*User, error) {
+	if ir.devSub != "" {
+		return &User{Sub: ir.devSub, Email: ir.devEmail, Admin: true}, nil
+	}
+
+	sub := strings.TrimSpace(r.Header.Get(ir.subHeader))
+	if sub == "" {
+		return nil, errNoIdentity
+	}
+
+	user := &User{Sub: sub, Email: strings.TrimSpace(r.Header.Get(ir.emailHeader))}
+	for _, group := range strings.Split(r.Header.Get(ir.groupsHeader), ",") {
+		if ir.adminGroups[strings.TrimSpace(group)] {
+			user.Admin = true
+			break
+		}
+	}
+	return user, nil
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func parseAdminGroups(raw string) map[string]bool {
+	groups := map[string]bool{}
+	for _, g := range strings.Split(raw, ",") {
+		g = strings.TrimSpace(g)
+		if g != "" {
+			groups[g] = true
+		}
+	}
+	return groups
+}

--- a/internal/portal/server.go
+++ b/internal/portal/server.go
@@ -1,0 +1,368 @@
+package portal
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gorilla/handlers"
+
+	"github.com/chanzuckerberg/aws-oidc/pkg/okta"
+)
+
+//go:embed templates/*.html
+var templatesFS embed.FS
+
+var agentNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// Config wires the portal's dependencies.
+type Config struct {
+	Apps             okta.AppLister
+	MappingsProvider MappingsProvider
+	Store            AgentStore
+	Identity         *IdentityResolver
+}
+
+// Server is the agent-registry portal.
+type Server struct {
+	cfg  Config
+	tmpl *template.Template
+}
+
+// NewServer parses templates and returns a portal server.
+func NewServer(cfg Config) (*Server, error) {
+	tmpl, err := template.New("").ParseFS(templatesFS, "templates/*.html")
+	if err != nil {
+		return nil, fmt.Errorf("parsing templates: %w", err)
+	}
+	return &Server{cfg: cfg, tmpl: tmpl}, nil
+}
+
+// Handler returns the HTTP handler for the portal.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("GET /{$}", s.handleList)
+	mux.HandleFunc("GET /agents/new", s.handleNew)
+	mux.HandleFunc("POST /agents", s.handleCreate)
+	mux.HandleFunc("GET /agents/{name}", s.handleView)
+	mux.HandleFunc("POST /agents/{name}", s.handleUpdate)
+	mux.HandleFunc("POST /agents/{name}/delete", s.handleDelete)
+
+	recovery := handlers.RecoveryHandler(
+		handlers.PrintRecoveryStack(true),
+		handlers.RecoveryLogger(recoveryLogger{slog.Default()}),
+	)
+	return recovery(mux)
+}
+
+type pageData struct {
+	Title        string
+	User         *User
+	Agents       []Agent
+	Agent        *Agent
+	Entitlements *Entitlements
+	Checked      map[string]bool
+	Action       string
+	Error        string
+}
+
+func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user(w, r)
+	if !ok {
+		return
+	}
+	ctx := r.Context()
+
+	var (
+		agents []Agent
+		err    error
+	)
+	if user.Admin {
+		agents, err = s.cfg.Store.List(ctx)
+	} else {
+		agents, err = s.cfg.Store.ListByOwner(ctx, user.Sub)
+	}
+	if err != nil {
+		s.fail(w, "listing agents", err)
+		return
+	}
+
+	s.render(w, "list", pageData{Title: "Your agents", User: user, Agents: agents})
+}
+
+func (s *Server) handleNew(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user(w, r)
+	if !ok {
+		return
+	}
+	ent, err := s.entitlements(r.Context(), user.Sub)
+	if err != nil {
+		s.fail(w, "resolving entitlements", err)
+		return
+	}
+	s.render(w, "form", pageData{
+		Title:        "Register agent",
+		User:         user,
+		Entitlements: ent,
+		Checked:      map[string]bool{},
+		Action:       "/agents",
+	})
+}
+
+func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user(w, r)
+	if !ok {
+		return
+	}
+	ctx := r.Context()
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+
+	ent, err := s.entitlements(ctx, user.Sub)
+	if err != nil {
+		s.fail(w, "resolving entitlements", err)
+		return
+	}
+
+	name := strings.TrimSpace(r.FormValue("name"))
+	renderErr := func(msg string) {
+		s.render(w, "form", pageData{
+			Title: "Register agent", User: user, Entitlements: ent,
+			Checked: checkedFromForm(r), Action: "/agents", Error: msg,
+		})
+	}
+
+	if !agentNameRe.MatchString(name) {
+		renderErr("Name must be non-empty and use only letters, numbers, dashes, or underscores.")
+		return
+	}
+
+	existing, err := s.cfg.Store.Get(ctx, name)
+	if err != nil {
+		s.fail(w, "checking existing agent", err)
+		return
+	}
+	if existing != nil {
+		renderErr(fmt.Sprintf("An agent named %q already exists.", name))
+		return
+	}
+
+	grants, err := parseGrants(r, ent)
+	if err != nil {
+		renderErr(err.Error())
+		return
+	}
+
+	now := time.Now().UTC()
+	err = s.cfg.Store.Upsert(ctx, Agent{
+		Name:       name,
+		Owner:      user.Sub,
+		OwnerEmail: user.Email,
+		Grants:     grants,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+	if err != nil {
+		s.fail(w, "saving agent", err)
+		return
+	}
+
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func (s *Server) handleView(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user(w, r)
+	if !ok {
+		return
+	}
+	ctx := r.Context()
+
+	agent, ok := s.ownedAgent(w, r, user)
+	if !ok {
+		return
+	}
+
+	// Bound the choices by the owner's access, not the (possibly admin) editor's.
+	ent, err := s.entitlements(ctx, agent.Owner)
+	if err != nil {
+		s.fail(w, "resolving entitlements", err)
+		return
+	}
+
+	s.render(w, "form", pageData{
+		Title:        "Edit " + agent.Name,
+		User:         user,
+		Agent:        agent,
+		Entitlements: ent,
+		Checked:      checkedFromAgent(agent),
+		Action:       "/agents/" + agent.Name,
+	})
+}
+
+func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user(w, r)
+	if !ok {
+		return
+	}
+	ctx := r.Context()
+
+	agent, ok := s.ownedAgent(w, r, user)
+	if !ok {
+		return
+	}
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+
+	ent, err := s.entitlements(ctx, agent.Owner)
+	if err != nil {
+		s.fail(w, "resolving entitlements", err)
+		return
+	}
+
+	grants, err := parseGrants(r, ent)
+	if err != nil {
+		s.render(w, "form", pageData{
+			Title: "Edit " + agent.Name, User: user, Agent: agent, Entitlements: ent,
+			Checked: checkedFromForm(r), Action: "/agents/" + agent.Name, Error: err.Error(),
+		})
+		return
+	}
+
+	agent.Grants = grants
+	agent.UpdatedAt = time.Now().UTC()
+	err = s.cfg.Store.Upsert(ctx, *agent)
+	if err != nil {
+		s.fail(w, "updating agent", err)
+		return
+	}
+
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.user(w, r)
+	if !ok {
+		return
+	}
+
+	agent, ok := s.ownedAgent(w, r, user)
+	if !ok {
+		return
+	}
+
+	err := s.cfg.Store.Delete(r.Context(), agent.Name)
+	if err != nil {
+		s.fail(w, "deleting agent", err)
+		return
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+// ownedAgent loads the agent named in the path and enforces that the current user may act
+// on it (owner or admin). It writes the response and returns ok=false on any failure.
+func (s *Server) ownedAgent(w http.ResponseWriter, r *http.Request, user *User) (*Agent, bool) {
+	name := r.PathValue("name")
+	agent, err := s.cfg.Store.Get(r.Context(), name)
+	if err != nil {
+		s.fail(w, "loading agent", err)
+		return nil, false
+	}
+	if agent == nil {
+		http.Error(w, "agent not found", http.StatusNotFound)
+		return nil, false
+	}
+	if agent.Owner != user.Sub && !user.Admin {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return nil, false
+	}
+	return agent, true
+}
+
+func (s *Server) entitlements(ctx context.Context, sub string) (*Entitlements, error) {
+	mappings, err := s.cfg.MappingsProvider(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading rolemap: %w", err)
+	}
+	return ResolveEntitlements(ctx, sub, s.cfg.Apps, mappings)
+}
+
+func (s *Server) user(w http.ResponseWriter, r *http.Request) (*User, bool) {
+	user, err := s.cfg.Identity.Resolve(r)
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return nil, false
+	}
+	return user, true
+}
+
+func (s *Server) render(w http.ResponseWriter, name string, data pageData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	err := s.tmpl.ExecuteTemplate(w, name, data)
+	if err != nil {
+		slog.Error("rendering template", "template", name, "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) fail(w http.ResponseWriter, what string, err error) {
+	slog.Error(what, "error", err)
+	http.Error(w, "internal error", http.StatusInternalServerError)
+}
+
+// parseGrants reads the selected grants from the form and validates each one is within the
+// entitlements, enforcing that an agent gets only a subset of the owner's access.
+func parseGrants(r *http.Request, ent *Entitlements) ([]Grant, error) {
+	selected := r.Form["grant"]
+	grants := make([]Grant, 0, len(selected))
+	for _, raw := range selected {
+		accountID, roleARN, ok := strings.Cut(raw, "|")
+		if !ok {
+			return nil, fmt.Errorf("malformed selection %q", raw)
+		}
+		grant, allowed := ent.Allows(accountID, roleARN)
+		if !allowed {
+			return nil, fmt.Errorf("you do not have access to %s in account %s", roleARN, accountID)
+		}
+		grants = append(grants, grant)
+	}
+	return grants, nil
+}
+
+func checkedFromForm(r *http.Request) map[string]bool {
+	checked := map[string]bool{}
+	for _, raw := range r.Form["grant"] {
+		checked[raw] = true
+	}
+	return checked
+}
+
+func checkedFromAgent(agent *Agent) map[string]bool {
+	checked := map[string]bool{}
+	for _, g := range agent.Grants {
+		checked[g.Key()] = true
+	}
+	return checked
+}
+
+type recoveryLogger struct {
+	logger *slog.Logger
+}
+
+func (l recoveryLogger) Println(v ...interface{}) {
+	l.logger.Error(fmt.Sprint(v...))
+}

--- a/internal/portal/server_test.go
+++ b/internal/portal/server_test.go
@@ -1,0 +1,48 @@
+package portal
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplatesRender(t *testing.T) {
+	s, err := NewServer(Config{})
+	require.NoError(t, err)
+
+	ent := &Entitlements{
+		Accounts: []AccountAccess{{
+			AccountID:    "111",
+			AccountAlias: "prod",
+			Roles:        []RoleAccess{{RoleARN: "arn:aws:iam::111:role/x", RoleName: "x"}},
+		}},
+		allowed: map[string]Grant{},
+	}
+
+	// Form renders, and the current grant is pre-checked.
+	rec := httptest.NewRecorder()
+	s.render(rec, "form", pageData{
+		Title:        "Edit",
+		User:         &User{Sub: "s", Email: "a@example.com"},
+		Agent:        &Agent{Name: "bot"},
+		Entitlements: ent,
+		Checked:      map[string]bool{"111|arn:aws:iam::111:role/x": true},
+		Action:       "/agents/bot",
+	})
+	require.Equal(t, 200, rec.Code)
+	body := rec.Body.String()
+	require.Contains(t, body, `type="checkbox"`)
+	require.Contains(t, body, "checked")
+	require.Contains(t, body, "prod")
+
+	// List renders with an agent row.
+	rec = httptest.NewRecorder()
+	s.render(rec, "list", pageData{
+		Title:  "Your agents",
+		User:   &User{Sub: "s"},
+		Agents: []Agent{{Name: "bot", Grants: []Grant{{AccountAlias: "prod", RoleName: "x"}}}},
+	})
+	require.Equal(t, 200, rec.Code)
+	require.Contains(t, rec.Body.String(), "bot")
+}

--- a/internal/portal/store.go
+++ b/internal/portal/store.go
@@ -1,0 +1,201 @@
+// Package portal implements the agent-registry control plane UI and API: a person logs
+// in, sees the AWS access they already have, registers agents, and grants each agent a
+// subset of that access.
+//
+// This is the hackathon iteration. Agents are stored as YAML in a single ConfigMap and
+// there is no operator yet, so grants are recorded but not provisioned into IAM. The
+// plan's target is Agent custom resources reconciled by an operator; the AgentStore
+// interface is the seam that swap targets later.
+package portal
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Grant is a single account plus role an agent may assume. It must always be a subset of
+// the owner's own access, enforced when a grant is written.
+type Grant struct {
+	AccountID    string `yaml:"account_id"`
+	AccountAlias string `yaml:"account_alias"`
+	RoleARN      string `yaml:"role_arn"`
+	RoleName     string `yaml:"role_name"`
+}
+
+// Key uniquely identifies a grant by account and role.
+func (g Grant) Key() string {
+	return g.AccountID + "|" + g.RoleARN
+}
+
+// Agent is a registered agent and the access granted to it. Owner is the Okta subject of
+// the person who registered it.
+type Agent struct {
+	Name       string    `yaml:"name"`
+	Owner      string    `yaml:"owner"`
+	OwnerEmail string    `yaml:"owner_email"`
+	Grants     []Grant   `yaml:"grants"`
+	CreatedAt  time.Time `yaml:"created_at"`
+	UpdatedAt  time.Time `yaml:"updated_at"`
+}
+
+// AgentStore persists agents.
+type AgentStore interface {
+	List(ctx context.Context) ([]Agent, error)
+	ListByOwner(ctx context.Context, owner string) ([]Agent, error)
+	Get(ctx context.Context, name string) (*Agent, error)
+	Upsert(ctx context.Context, agent Agent) error
+	Delete(ctx context.Context, name string) error
+}
+
+// configMapStore stores the whole registry as YAML under one key in one ConfigMap.
+type configMapStore struct {
+	client    kubernetes.Interface
+	namespace string
+	name      string
+	key       string
+}
+
+var _ AgentStore = (*configMapStore)(nil)
+
+// NewConfigMapStore returns an AgentStore backed by a single ConfigMap.
+func NewConfigMapStore(client kubernetes.Interface, namespace, name, key string) *configMapStore {
+	return &configMapStore{client: client, namespace: namespace, name: name, key: key}
+}
+
+type registryFile struct {
+	Agents []Agent `yaml:"agents"`
+}
+
+// read returns the current ConfigMap (nil if it does not exist yet) and the agents in it.
+func (s *configMapStore) read(ctx context.Context) (*corev1.ConfigMap, []Agent, error) {
+	cm, err := s.client.CoreV1().ConfigMaps(s.namespace).Get(ctx, s.name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("getting configmap %s/%s: %w", s.namespace, s.name, err)
+	}
+
+	raw, ok := cm.Data[s.key]
+	if !ok || raw == "" {
+		return cm, nil, nil
+	}
+
+	file := registryFile{}
+	err = yaml.Unmarshal([]byte(raw), &file)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unmarshalling agent registry %s/%s key %q: %w", s.namespace, s.name, s.key, err)
+	}
+	return cm, file.Agents, nil
+}
+
+func (s *configMapStore) List(ctx context.Context) ([]Agent, error) {
+	_, agents, err := s.read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(agents, func(i, j int) bool { return agents[i].Name < agents[j].Name })
+	return agents, nil
+}
+
+func (s *configMapStore) ListByOwner(ctx context.Context, owner string) ([]Agent, error) {
+	agents, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	owned := make([]Agent, 0, len(agents))
+	for _, a := range agents {
+		if a.Owner == owner {
+			owned = append(owned, a)
+		}
+	}
+	return owned, nil
+}
+
+func (s *configMapStore) Get(ctx context.Context, name string) (*Agent, error) {
+	agents, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range agents {
+		if agents[i].Name == name {
+			found := agents[i]
+			return &found, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *configMapStore) write(ctx context.Context, cm *corev1.ConfigMap, agents []Agent) error {
+	sort.Slice(agents, func(i, j int) bool { return agents[i].Name < agents[j].Name })
+	data, err := yaml.Marshal(registryFile{Agents: agents})
+	if err != nil {
+		return fmt.Errorf("marshalling agent registry: %w", err)
+	}
+
+	configMaps := s.client.CoreV1().ConfigMaps(s.namespace)
+	if cm == nil {
+		_, err = configMaps.Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: s.name, Namespace: s.namespace},
+			Data:       map[string]string{s.key: string(data)},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("creating configmap %s/%s: %w", s.namespace, s.name, err)
+		}
+		return nil
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data[s.key] = string(data)
+	_, err = configMaps.Update(ctx, cm, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating configmap %s/%s: %w", s.namespace, s.name, err)
+	}
+	return nil
+}
+
+func (s *configMapStore) Upsert(ctx context.Context, agent Agent) error {
+	cm, agents, err := s.read(ctx)
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for i := range agents {
+		if agents[i].Name == agent.Name {
+			agents[i] = agent
+			found = true
+			break
+		}
+	}
+	if !found {
+		agents = append(agents, agent)
+	}
+	return s.write(ctx, cm, agents)
+}
+
+func (s *configMapStore) Delete(ctx context.Context, name string) error {
+	cm, agents, err := s.read(ctx)
+	if err != nil {
+		return err
+	}
+
+	kept := make([]Agent, 0, len(agents))
+	for _, a := range agents {
+		if a.Name != name {
+			kept = append(kept, a)
+		}
+	}
+	return s.write(ctx, cm, kept)
+}

--- a/internal/portal/store_test.go
+++ b/internal/portal/store_test.go
@@ -1,0 +1,76 @@
+package portal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestConfigMapStore(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+	store := NewConfigMapStore(client, "test-ns", "agent-registry", "agents.yaml")
+
+	// Empty registry (ConfigMap does not exist yet).
+	agents, err := store.List(ctx)
+	require.NoError(t, err)
+	require.Empty(t, agents)
+
+	got, err := store.Get(ctx, "missing")
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	// Create.
+	bot := Agent{
+		Name:       "data-bot",
+		Owner:      "sub-1",
+		OwnerEmail: "a@example.com",
+		Grants: []Grant{
+			{AccountID: "111", AccountAlias: "prod", RoleARN: "arn:aws:iam::111:role/agents/data-bot-ro", RoleName: "agents/data-bot-ro"},
+		},
+	}
+	require.NoError(t, store.Upsert(ctx, bot))
+
+	got, err = store.Get(ctx, "data-bot")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "sub-1", got.Owner)
+	require.Len(t, got.Grants, 1)
+
+	// Owner scoping.
+	owned, err := store.ListByOwner(ctx, "sub-1")
+	require.NoError(t, err)
+	require.Len(t, owned, 1)
+
+	none, err := store.ListByOwner(ctx, "someone-else")
+	require.NoError(t, err)
+	require.Empty(t, none)
+
+	// A second agent for a different owner does not leak across owners.
+	require.NoError(t, store.Upsert(ctx, Agent{Name: "other-bot", Owner: "sub-2"}))
+	all, err := store.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	owned, err = store.ListByOwner(ctx, "sub-1")
+	require.NoError(t, err)
+	require.Len(t, owned, 1)
+
+	// Update in place.
+	bot.Grants = nil
+	require.NoError(t, store.Upsert(ctx, bot))
+	got, err = store.Get(ctx, "data-bot")
+	require.NoError(t, err)
+	require.Empty(t, got.Grants)
+
+	// Delete.
+	require.NoError(t, store.Delete(ctx, "data-bot"))
+	got, err = store.Get(ctx, "data-bot")
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	all, err = store.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+}

--- a/internal/portal/templates/form.html
+++ b/internal/portal/templates/form.html
@@ -1,0 +1,39 @@
+{{define "form"}}{{template "head" .}}
+  <h1>{{if .Agent}}Edit agent: {{.Agent.Name}}{{else}}Register new agent{{end}}</h1>
+  {{if .Error}}<p class="err">{{.Error}}</p>{{end}}
+
+  <form method="post" action="{{.Action}}">
+    {{if not .Agent}}
+    <p><label>Name <input name="name" required pattern="[a-zA-Z0-9_-]+" placeholder="my-agent"></label></p>
+    {{end}}
+
+    <p class="muted">Select the access to grant. You can only grant access you already have.</p>
+
+    {{range .Entitlements.Accounts}}
+    {{$acct := .}}
+    <fieldset>
+      <legend>{{.Label}} <span class="muted">({{.AccountID}})</span></legend>
+      {{range .Roles}}
+      <label class="grant">
+        <input type="checkbox" name="grant" value="{{$acct.AccountID}}|{{.RoleARN}}"
+          {{if index $.Checked (printf "%s|%s" $acct.AccountID .RoleARN)}}checked{{end}}>
+        {{.RoleName}}
+      </label>
+      {{end}}
+    </fieldset>
+    {{else}}
+    <p class="muted">You have no AWS access to grant.</p>
+    {{end}}
+
+    <p>
+      <button class="btn primary" type="submit">Save</button>
+      <a class="btn" href="/">Cancel</a>
+    </p>
+  </form>
+
+  {{if .Agent}}
+  <form class="inline" method="post" action="/agents/{{.Agent.Name}}/delete" onsubmit="return confirm('Delete {{.Agent.Name}}?');">
+    <button class="btn danger" type="submit">Delete agent</button>
+  </form>
+  {{end}}
+{{template "foot" .}}{{end}}

--- a/internal/portal/templates/layout.html
+++ b/internal/portal/templates/layout.html
@@ -1,0 +1,38 @@
+{{define "head"}}<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{.Title}} — Agent Registry</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 900px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }
+    header { display: flex; align-items: baseline; gap: .5rem; }
+    header a { font-weight: 600; text-decoration: none; color: inherit; }
+    .muted { color: #666; }
+    table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+    th, td { border: 1px solid #ddd; padding: .45rem .6rem; text-align: left; vertical-align: top; }
+    th { background: #f6f6f6; }
+    .btn { display: inline-block; padding: .35rem .7rem; border: 1px solid #888; border-radius: 5px; text-decoration: none; color: inherit; background: #fafafa; cursor: pointer; }
+    .btn.primary { background: #1a5; border-color: #1a5; color: #fff; }
+    fieldset { margin: .6rem 0; border: 1px solid #ddd; border-radius: 5px; }
+    legend { font-weight: 600; }
+    label.grant { display: block; padding: .15rem 0; }
+    .err { color: #b00020; font-weight: 600; }
+    .danger { color: #b00020; }
+    form.inline { display: inline; }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="/">Agent Registry</a>
+    {{if .User}}<span class="muted">— {{if .User.Email}}{{.User.Email}}{{else}}{{.User.Sub}}{{end}}{{if .User.Admin}} · admin{{end}}</span>{{end}}
+  </header>
+  <hr>
+{{end}}
+
+{{define "foot"}}
+  <hr>
+  <footer class="muted">aws-oidc agent registry · hackathon build</footer>
+</body>
+</html>
+{{end}}

--- a/internal/portal/templates/list.html
+++ b/internal/portal/templates/list.html
@@ -16,7 +16,12 @@
       <td>
         {{range .Grants}}{{.AccountAlias}} / {{.RoleName}}<br>{{else}}<span class="muted">none</span>{{end}}
       </td>
-      <td><a href="/agents/{{.Name}}">edit</a></td>
+      <td>
+        <a class="btn" href="/agents/{{.Name}}">edit</a>
+        <form class="inline" method="post" action="/agents/{{.Name}}/delete" onsubmit="return confirm('Delete {{.Name}}?');">
+          <button class="btn danger" type="submit">delete</button>
+        </form>
+      </td>
     </tr>
     {{end}}
   </table>

--- a/internal/portal/templates/list.html
+++ b/internal/portal/templates/list.html
@@ -1,0 +1,26 @@
+{{define "list"}}{{template "head" .}}
+  <h1>{{if .User.Admin}}All agents{{else}}Your agents{{end}}</h1>
+  <p><a class="btn primary" href="/agents/new">Register new agent</a></p>
+  {{if .Agents}}
+  <table>
+    <tr>
+      <th>Name</th>
+      {{if .User.Admin}}<th>Owner</th>{{end}}
+      <th>Granted access (account / role)</th>
+      <th></th>
+    </tr>
+    {{range .Agents}}
+    <tr>
+      <td>{{.Name}}</td>
+      {{if $.User.Admin}}<td class="muted">{{if .OwnerEmail}}{{.OwnerEmail}}{{else}}{{.Owner}}{{end}}</td>{{end}}
+      <td>
+        {{range .Grants}}{{.AccountAlias}} / {{.RoleName}}<br>{{else}}<span class="muted">none</span>{{end}}
+      </td>
+      <td><a href="/agents/{{.Name}}">edit</a></td>
+    </tr>
+    {{end}}
+  </table>
+  {{else}}
+  <p class="muted">No agents yet. Register one to grant it a slice of your AWS access.</p>
+  {{end}}
+{{template "foot" .}}{{end}}


### PR DESCRIPTION
## Overview

First playable slice of the agent registry (see the plan in #1222, which this is stacked on). A person needs to register agents and grant each one a scoped subset of the AWS access they already have, and see and update those grants. This PR delivers the server, a dead-simple UI, and the per-user account/role dropdown so the flow can be exercised in an rdev stack.

## Solution

Adds an `aws-oidc serve-portal` subcommand that runs a minimal server-rendered HTML portal (no SPA, no frontend build), living in the aws-oidc image alongside the config server and rolemap cronjob.

- The grantable accounts and roles are correlated to the logged-in user: the portal resolves the user's Okta apps (`okta.GetClientIDs`) and looks them up in the existing `rolemap` ConfigMap, the same way the config server builds a human's aws config. An agent can only be granted a subset of what its owner already has, enforced server-side on every write.
- Users can register agents, see their agents and granted access, update access, and deregister. Agents are stored in an `agent-registry` ConfigMap for now; the plan's operator will reconcile them into IAM roles later. The `AgentStore` interface is the seam for that swap.
- Identity is a pluggable resolver. Real Okta browser login is a follow-up; for rdev play, set `PORTAL_DEV_SUB` to your Okta user id (you are treated as admin so you can see all agents). An auth-proxy header mode is also supported.

Wired as an rdev-only service with RBAC for the rolemap read and the agent-registry read/write. Prod is intentionally untouched because there is no browser login yet.

## Impact

New optional workload in the aws-oidc app, rdev only. No change to the existing config server, rolemap cronjob, or prod. Reuses `pkg/okta` and `pkg/configmap`.

## Try it in rdev

- Spin up an rdev stack from this branch.
- Set `PORTAL_DEV_SUB` in `.infra/rdev/values.yaml` to your Okta user id, then redeploy.
- Open the portal route, register an agent, and pick from your accounts and roles.

## References

- Stacked on the plan PR #1222 (base branch `heathj/agent-registry-control-plane-plan`).
- Follow-ups from the plan: Agent CRD plus operator, admission webhook, real Okta login, and the shared-infra per-account bootstrap.