### PR TITLE
feat(operator): wire the real agent Okta app client id

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -79,10 +79,8 @@ stack:
         - --leader-election=false
         # Serve health on the stack service port so the default probes reach it.
         - --health-probe-bind-address=:8080
-        # TODO: the shared agent Okta app is not created yet (shared-infra okta-czi). Until
-        # its client id is wired in, provisioned role trust policies use this placeholder
-        # audience and no agent can actually assume them.
-        - --okta-app-client-id=agent-registry-placeholder
+        # Shared agent Okta app client id (shared-infra okta-czi output oidc_agent_client_id).
+        - --okta-app-client-id=0oa1djle01a21Qbo71t8
         - --provisioner-role-name=agent-provisioner
         # Standard tags applied to every agent role, alongside the operator's own
         # managedBy/owner and per-agent tags.

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -3,7 +3,7 @@ stack:
   services:
     aws-oidc:
       image:
-        tag: sha-695c82e
+        tag: sha-68ed5c1
       # This rdev stack is for the portal, which owns the stack root path. The config
       # server is not exercised here, so disable its ingress to avoid a host+path
       # collision with the portal.
@@ -14,7 +14,7 @@ stack:
     portal:
       image:
         repository: 533267185808.dkr.ecr.us-west-2.amazonaws.com/core-platform/aws-oidc/aws-oidc
-        tag: sha-695c82e
+        tag: sha-68ed5c1
       serviceAccount:
         create: true
         name: portal
@@ -60,7 +60,7 @@ stack:
         repository: 533267185808.dkr.ecr.us-west-2.amazonaws.com/core-platform/aws-oidc/aws-oidc
         # Pin to an immutable sha tag (not the mutable branch tag) so a new image is actually
         # pulled on change; with the branch tag and IfNotPresent, nodes cache a stale image.
-        tag: sha-695c82e
+        tag: sha-68ed5c1
       serviceAccount:
         create: true
         name: agent-operator

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -34,7 +34,7 @@ const (
 
 func init() {
 	rootCmd.AddCommand(operatorCmd)
-	operatorCmd.Flags().String(flagOktaAppClientID, "", "Client id of the shared agent Okta app used as the IAM trust audience (TODO: app not created yet)")
+	operatorCmd.Flags().String(flagOktaAppClientID, "", "Client id of the shared agent Okta app used as the IAM trust audience")
 	operatorCmd.Flags().String(flagIssuerHost, "czi.okta.com", "Okta issuer host (without scheme) that names the account OIDC provider")
 	operatorCmd.Flags().String(flagBoundaryPolicyName, "", "Permissions boundary policy name applied to every agent role (TODO: boundary not created yet; empty skips it)")
 	operatorCmd.Flags().Bool(flagLeaderElection, true, "Enable leader election so only one operator replica reconciles")

--- a/internal/providers/aws/aws.go
+++ b/internal/providers/aws/aws.go
@@ -2,12 +2,9 @@
 // per-agent IAM role in the grant's account. The role trusts the shared agent Okta app via
 // web-identity federation, scoped to the owning subject.
 //
-// This is the first iteration. It creates the role if it does not already exist; several
-// pieces it depends on do not exist yet and are marked with TODOs:
-//   - the shared agent Okta app (its client id feeds the trust policy audience),
-//   - cross-account access (assuming each account's agent-provisioner role),
-//   - the permissions boundary,
-//   - the permissions policy that scopes the agent to a subset of the owner's role.
+// It creates the role if it does not already exist and mirrors the source role's policies
+// onto it. The permissions boundary is still a TODO: it is applied only when
+// BoundaryPolicyName is set, which awaits the shared-infra bootstrap.
 package aws
 
 import (
@@ -55,11 +52,7 @@ type Config struct {
 	// names the account's OIDC provider and prefixes the trust condition keys.
 	IssuerHost string
 	// OktaAppClientID is the shared agent Okta app client id used as the trust policy
-	// audience.
-	//
-	// TODO: this app does not exist yet. It is being created in shared-infra under
-	// okta-czi. Until its client id is wired in here, the aud condition will not match any
-	// real token and no agent can actually assume the role.
+	// audience. The app lives in shared-infra under okta-czi (output oidc_agent_client_id).
 	OktaAppClientID string
 	// RolePath is the IAM path every agent role lives under (must start and end with "/").
 	RolePath string


### PR DESCRIPTION
## Overview

The operator wrote agent-role trust policies against a placeholder audience because the shared agent Okta app did not exist yet. It now exists (shared-infra okta-czi, output `oidc_agent_client_id`), so the placeholder can go.

## Solution

Drop the `agent-registry-placeholder` stub and the "app not created yet" TODOs, and pass the real client id (`0oa1djle01a21Qbo71t8`) to the rdev operator. The trust policies the operator writes now carry a real audience that an agent's Okta token can actually match.

## Impact

Agent roles the operator provisions become genuinely assumable by agent tokens from the shared Okta app, instead of trusting an audience nothing issues.

## References

- Stacked on `heathj/agent-registry-control-plane-plan` (PR #1222).
- Depends on the merged shared-infra agent Okta app (shared-infra #11950).

| Tracked in Jira: [CCIE-7018](https://czi.atlassian.net/browse/CCIE-7018) |
| ------------------------------------------------------------------------ |

[CCIE-7018]: https://czi.atlassian.net/browse/CCIE-7018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ