### PR TITLE
feat(operator): trust an agent's thread service accounts on its roles

### DIFF
--- a/internal/providers/aws/aws.go
+++ b/internal/providers/aws/aws.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -34,6 +35,7 @@ type IAMAPI interface {
 	GetRole(ctx context.Context, in *iam.GetRoleInput, opts ...func(*iam.Options)) (*iam.GetRoleOutput, error)
 	CreateRole(ctx context.Context, in *iam.CreateRoleInput, opts ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
 	DeleteRole(ctx context.Context, in *iam.DeleteRoleInput, opts ...func(*iam.Options)) (*iam.DeleteRoleOutput, error)
+	UpdateAssumeRolePolicy(ctx context.Context, in *iam.UpdateAssumeRolePolicyInput, opts ...func(*iam.Options)) (*iam.UpdateAssumeRolePolicyOutput, error)
 	ListAttachedRolePolicies(ctx context.Context, in *iam.ListAttachedRolePoliciesInput, opts ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error)
 	AttachRolePolicy(ctx context.Context, in *iam.AttachRolePolicyInput, opts ...func(*iam.Options)) (*iam.AttachRolePolicyOutput, error)
 	DetachRolePolicy(ctx context.Context, in *iam.DetachRolePolicyInput, opts ...func(*iam.Options)) (*iam.DetachRolePolicyOutput, error)
@@ -54,6 +56,15 @@ type Config struct {
 	// OktaAppClientID is the shared agent Okta app client id used as the trust policy
 	// audience. The app lives in shared-infra under okta-czi (output oidc_agent_client_id).
 	OktaAppClientID string
+	// ClusterOIDCProvider is the EKS cluster's OIDC issuer without scheme (for example
+	// "oidc.eks.us-west-2.amazonaws.com/id/EXAMPLE"). Agent roles trust it so an agent's
+	// thread pods can assume them with their projected service account tokens. Empty leaves
+	// the cluster statement off, which is what keeps the provider usable in accounts where
+	// the issuer is not registered yet.
+	ClusterOIDCProvider string
+	// PodNamespace is the namespace the agent's threads run in. It scopes the service account
+	// subject the cluster trust statement matches.
+	PodNamespace string
 	// RolePath is the IAM path every agent role lives under (must start and end with "/").
 	RolePath string
 	// BoundaryPolicyName is the permissions boundary policy name, resolved per account.
@@ -70,6 +81,10 @@ type Config struct {
 // managedByValue is the managedBy tag value for roles this operator creates, matching the
 // standard tagging convention (Terraform-managed resources use "terraform").
 const managedByValue = "aws-oidc-agent-operator"
+
+// clusterTokenAudience is the audience the agent pods' projected service account tokens carry
+// and the only one the cluster trust statement accepts.
+const clusterTokenAudience = "sts.amazonaws.com"
 
 // Provider provisions AWS grants.
 type Provider struct {
@@ -115,19 +130,27 @@ func (p *Provider) Ensure(ctx context.Context, agent *agentsv1.Agent, grant agen
 	roleName := p.roleName(agent, g)
 	sourceRole := sourceRoleName(g)
 
+	trust, err := p.trustPolicy(g.AccountID, agent)
+	if err != nil {
+		return status, err
+	}
+
 	existing, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: awssdk.String(roleName)})
 	roleARN := ""
 	if err == nil {
 		roleARN = awssdk.ToString(existing.Role.Arn)
+
+		// The trust policy is not static: it gains and loses the cluster statement as the
+		// agent's runtime is enabled and disabled, so an existing role has to be corrected
+		// rather than left at whatever it was created with.
+		err = p.reconcileTrust(ctx, client, roleName, awssdk.ToString(existing.Role.AssumeRolePolicyDocument), trust)
+		if err != nil {
+			return status, err
+		}
 	} else {
 		var notFound *iamtypes.NoSuchEntityException
 		if !errors.As(err, &notFound) {
 			return status, fmt.Errorf("getting role %s: %w", roleName, err)
-		}
-
-		trust, trustErr := p.trustPolicy(g.AccountID, agent.Spec.Owner)
-		if trustErr != nil {
-			return status, trustErr
 		}
 
 		input := &iam.CreateRoleInput{
@@ -397,29 +420,108 @@ func coalesceUnknown(v string) string {
 	return v
 }
 
-// trustPolicy builds the web-identity trust document: the account's Okta OIDC provider,
-// conditioned on the agent app audience and the owner subject.
-func (p *Provider) trustPolicy(accountID, owner string) (string, error) {
-	providerARN := fmt.Sprintf("arn:aws:iam::%s:oidc-provider/%s", accountID, p.cfg.IssuerHost)
+// trustPolicy builds the web-identity trust document. It always trusts the account's Okta
+// OIDC provider, conditioned on the agent app audience and the owner subject, which is the
+// path a human's agent takes on a laptop. When the agent also runs in the cluster it trusts
+// the cluster's OIDC issuer as well, so the thread pods can assume the role directly.
+func (p *Provider) trustPolicy(accountID string, agent *agentsv1.Agent) (string, error) {
+	statements := []map[string]any{p.oktaStatement(accountID, agent.Spec.Owner)}
+
+	if p.cfg.ClusterOIDCProvider != "" && agent.Spec.Runtime != nil {
+		statements = append(statements, p.clusterStatement(accountID, agent))
+	}
+
 	doc := map[string]any{
-		"Version": "2012-10-17",
-		"Statement": []map[string]any{{
-			"Effect":    "Allow",
-			"Principal": map[string]any{"Federated": providerARN},
-			"Action":    "sts:AssumeRoleWithWebIdentity",
-			"Condition": map[string]any{
-				"StringEquals": map[string]string{
-					p.cfg.IssuerHost + ":aud": p.cfg.OktaAppClientID,
-					p.cfg.IssuerHost + ":sub": owner,
-				},
-			},
-		}},
+		"Version":   "2012-10-17",
+		"Statement": statements,
 	}
 	raw, err := json.Marshal(doc)
 	if err != nil {
 		return "", fmt.Errorf("marshalling trust policy: %w", err)
 	}
 	return string(raw), nil
+}
+
+// oktaStatement trusts the shared agent Okta app, scoped to the owning subject.
+func (p *Provider) oktaStatement(accountID, owner string) map[string]any {
+	return map[string]any{
+		"Sid":       "OktaAgentApp",
+		"Effect":    "Allow",
+		"Principal": map[string]any{"Federated": oidcProviderARN(accountID, p.cfg.IssuerHost)},
+		"Action":    "sts:AssumeRoleWithWebIdentity",
+		"Condition": map[string]any{
+			"StringEquals": map[string]string{
+				p.cfg.IssuerHost + ":aud": p.cfg.OktaAppClientID,
+				p.cfg.IssuerHost + ":sub": owner,
+			},
+		},
+	}
+}
+
+// clusterStatement trusts the EKS cluster's OIDC issuer for every thread of this agent. The
+// subject is matched with StringLike against a prefix built from the agent's uid, so adding a
+// thread needs no IAM write. The prefix cannot be name-based: an agent named "foo-bar" would
+// produce service accounts matching an agent "foo"'s prefix and inherit access that is not
+// its owner's.
+func (p *Provider) clusterStatement(accountID string, agent *agentsv1.Agent) map[string]any {
+	return map[string]any{
+		"Sid":       "AgentThreadServiceAccounts",
+		"Effect":    "Allow",
+		"Principal": map[string]any{"Federated": oidcProviderARN(accountID, p.cfg.ClusterOIDCProvider)},
+		"Action":    "sts:AssumeRoleWithWebIdentity",
+		"Condition": map[string]any{
+			"StringEquals": map[string]string{
+				p.cfg.ClusterOIDCProvider + ":aud": clusterTokenAudience,
+			},
+			"StringLike": map[string]string{
+				p.cfg.ClusterOIDCProvider + ":sub": agent.ThreadSubjectPattern(p.cfg.PodNamespace),
+			},
+		},
+	}
+}
+
+// reconcileTrust rewrites the role's trust policy when it no longer matches the desired one.
+// IAM returns the current document URL-encoded, and formatting differs from what we sent, so
+// the comparison is on the parsed documents rather than the raw strings.
+func (p *Provider) reconcileTrust(ctx context.Context, client IAMAPI, roleName, current, desired string) error {
+	decoded, err := url.QueryUnescape(current)
+	if err != nil {
+		return fmt.Errorf("decoding trust policy of %s: %w", roleName, err)
+	}
+
+	same, err := sameJSON(decoded, desired)
+	if err != nil {
+		return fmt.Errorf("comparing trust policy of %s: %w", roleName, err)
+	}
+	if same {
+		return nil
+	}
+
+	_, err = client.UpdateAssumeRolePolicy(ctx, &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       awssdk.String(roleName),
+		PolicyDocument: awssdk.String(desired),
+	})
+	if err != nil {
+		return fmt.Errorf("updating trust policy of %s: %w", roleName, err)
+	}
+	return nil
+}
+
+func sameJSON(a, b string) (bool, error) {
+	var left, right any
+	err := json.Unmarshal([]byte(a), &left)
+	if err != nil {
+		return false, fmt.Errorf("unmarshalling current: %w", err)
+	}
+	err = json.Unmarshal([]byte(b), &right)
+	if err != nil {
+		return false, fmt.Errorf("unmarshalling desired: %w", err)
+	}
+	return reflect.DeepEqual(left, right), nil
+}
+
+func oidcProviderARN(accountID, issuerHost string) string {
+	return fmt.Sprintf("arn:aws:iam::%s:oidc-provider/%s", accountID, issuerHost)
 }
 
 func roleNameFromARN(roleARN string) string {

--- a/internal/providers/aws/aws_test.go
+++ b/internal/providers/aws/aws_test.go
@@ -2,8 +2,10 @@ package aws
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
@@ -18,20 +20,39 @@ type fakeIAM struct {
 	deleteErr error
 	// sourceAttached are the managed policy ARNs the source role has.
 	sourceAttached []string
+	// existingTrust, when set, makes GetRole report an existing role carrying this trust
+	// document (URL-encoded, the way IAM returns it). Empty means the role does not exist.
+	existingTrust string
 	// createdRoleName, attachedToAgent, and detachedFromAgent capture what the provider did.
 	createdRoleName   string
+	createdTrust      string
+	updatedTrust      string
 	attachedToAgent   []string
 	detachedFromAgent []string
 }
 
-func (f *fakeIAM) GetRole(context.Context, *iam.GetRoleInput, ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
-	return nil, &iamtypes.NoSuchEntityException{}
+func (f *fakeIAM) GetRole(_ context.Context, in *iam.GetRoleInput, _ ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	if f.existingTrust == "" {
+		return nil, &iamtypes.NoSuchEntityException{}
+	}
+	arn := "arn:aws:iam::111111111111:role/agents/" + *in.RoleName
+	return &iam.GetRoleOutput{Role: &iamtypes.Role{
+		Arn:                      &arn,
+		RoleName:                 in.RoleName,
+		AssumeRolePolicyDocument: strPtr(url.QueryEscape(f.existingTrust)),
+	}}, nil
 }
 
 func (f *fakeIAM) CreateRole(_ context.Context, in *iam.CreateRoleInput, _ ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
 	f.createdRoleName = *in.RoleName
+	f.createdTrust = *in.AssumeRolePolicyDocument
 	arn := "arn:aws:iam::111111111111:role/agents/" + *in.RoleName
 	return &iam.CreateRoleOutput{Role: &iamtypes.Role{Arn: &arn, RoleName: in.RoleName}}, nil
+}
+
+func (f *fakeIAM) UpdateAssumeRolePolicy(_ context.Context, in *iam.UpdateAssumeRolePolicyInput, _ ...func(*iam.Options)) (*iam.UpdateAssumeRolePolicyOutput, error) {
+	f.updatedTrust = *in.PolicyDocument
+	return &iam.UpdateAssumeRolePolicyOutput{}, nil
 }
 
 func (f *fakeIAM) DeleteRole(context.Context, *iam.DeleteRoleInput, ...func(*iam.Options)) (*iam.DeleteRoleOutput, error) {
@@ -188,6 +209,107 @@ func TestDeleteDetachesPoliciesFirst(t *testing.T) {
 	err := p.Delete(ctx, agent, awsGrant())
 	require.NoError(t, err)
 	require.Equal(t, []string{"arn:aws:iam::aws:policy/ReadOnlyAccess"}, f.detachedFromAgent)
+}
+
+// clusterProvider mirrors an EKS cluster's OIDC issuer host and path.
+const clusterProvider = "oidc.eks.us-west-2.amazonaws.com/id/EXAMPLE"
+
+func runtimeAgent() *agentsv1.Agent {
+	agent := &agentsv1.Agent{}
+	agent.Name = "bot"
+	agent.UID = "0f8fad5b-d9cb-469f-a165-70867728950e"
+	agent.Spec.Owner = "00uSUB123"
+	agent.Spec.Runtime = &agentsv1.AgentRuntime{}
+	return agent
+}
+
+func clusterProviderWithFake(f *fakeIAM) *Provider {
+	return NewProvider(Config{
+		OktaAppClientID:     "aud",
+		ClusterOIDCProvider: clusterProvider,
+		PodNamespace:        "argus-aws-oidc-rdev",
+	}, func(context.Context, string) (IAMAPI, error) { return f, nil })
+}
+
+// trustStatements pulls the statements out of a trust document, keyed by Sid.
+func trustStatements(t *testing.T, doc string) map[string]map[string]any {
+	t.Helper()
+	var parsed struct {
+		Statement []map[string]any `json:"Statement"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(doc), &parsed))
+
+	byStatementID := make(map[string]map[string]any, len(parsed.Statement))
+	for _, statement := range parsed.Statement {
+		sid, _ := statement["Sid"].(string)
+		byStatementID[sid] = statement
+	}
+	return byStatementID
+}
+
+func TestTrustPolicyTrustsThreadServiceAccounts(t *testing.T) {
+	f := &fakeIAM{}
+	agent := runtimeAgent()
+
+	_, err := clusterProviderWithFake(f).Ensure(context.Background(), agent, awsGrant())
+	require.NoError(t, err)
+
+	statements := trustStatements(t, f.createdTrust)
+	require.Len(t, statements, 2)
+
+	cluster := statements["AgentThreadServiceAccounts"]
+	require.Equal(t,
+		"arn:aws:iam::111111111111:oidc-provider/"+clusterProvider,
+		cluster["Principal"].(map[string]any)["Federated"],
+	)
+
+	condition := cluster["Condition"].(map[string]any)
+	require.Equal(t,
+		"sts.amazonaws.com",
+		condition["StringEquals"].(map[string]any)[clusterProvider+":aud"],
+	)
+	// One wildcard covers every thread, so adding a thread needs no IAM write. The prefix is
+	// the agent's uid, not its name, so it cannot match another agent's threads.
+	require.Equal(t,
+		"system:serviceaccount:argus-aws-oidc-rdev:agent-0f8fad5bd9cb-*",
+		condition["StringLike"].(map[string]any)[clusterProvider+":sub"],
+	)
+}
+
+func TestTrustPolicyOmitsClusterStatementWithoutRuntime(t *testing.T) {
+	f := &fakeIAM{}
+	agent := runtimeAgent()
+	agent.Spec.Runtime = nil
+
+	_, err := clusterProviderWithFake(f).Ensure(context.Background(), agent, awsGrant())
+	require.NoError(t, err)
+
+	statements := trustStatements(t, f.createdTrust)
+	require.Len(t, statements, 1)
+	require.Contains(t, statements, "OktaAgentApp")
+}
+
+func TestEnsureCorrectsTrustDriftOnExistingRole(t *testing.T) {
+	ctx := context.Background()
+	agent := runtimeAgent()
+
+	// A role created before the agent had a runtime trusts only Okta.
+	oktaOnly, err := NewProvider(Config{OktaAppClientID: "aud"}, nil).trustPolicy("111111111111", agent)
+	require.NoError(t, err)
+
+	f := &fakeIAM{existingTrust: oktaOnly}
+	p := clusterProviderWithFake(f)
+
+	_, err = p.Ensure(ctx, agent, awsGrant())
+	require.NoError(t, err)
+	require.Empty(t, f.createdRoleName, "an existing role must not be recreated")
+	require.Contains(t, f.updatedTrust, "AgentThreadServiceAccounts")
+
+	// Already correct: no write, so a steady-state resync does not churn IAM.
+	settled := &fakeIAM{existingTrust: f.updatedTrust}
+	_, err = clusterProviderWithFake(settled).Ensure(ctx, agent, awsGrant())
+	require.NoError(t, err)
+	require.Empty(t, settled.updatedTrust)
 }
 
 func TestUnreachableAccount(t *testing.T) {


### PR DESCRIPTION
## Overview

An agent's IAM roles can only be assumed by a person going through Okta. A pod running as that agent has no way in, so nothing in the cluster can use the permissions we provision.

This PR extends the trust policy on every role the operator provisions so the agent's own pods can assume it, using the projected service account token the cluster already gives them.

## Solution

When the operator is configured with a cluster OIDC provider and the agent has a runtime, the role's trust policy gains a second statement federating to that cluster's OIDC provider. The Okta statement stays untouched, so a human keeps the access they had.

The new statement matches the `sub` claim with `StringLike` against a pattern derived from the agent's UID. Every thread's service account name starts with that UID-derived prefix, so one wildcard covers all of an agent's threads and cannot match another agent's, whatever the threads are named. A per-thread statement would work too, but the trust policy has a size limit and threads come and go, so a single stable statement is the safer shape.

Trust is now reconciled rather than only set at creation. The operator compares the desired policy against what is on the role semantically, ignoring key order and whitespace, and calls `UpdateAssumeRolePolicy` only on a real difference. Without this, an agent that gains a runtime after its role already exists would never become assumable, and drift would persist silently.

## Impact

Roles for agents with a runtime become assumable from inside the cluster by that agent's pods and nothing else. Agents without a runtime get the same policy they have today.

This needs the companion shared-infra PR to land first. It grants the provisioner `iam:UpdateAssumeRolePolicy` and registers the cluster's OIDC issuer as a provider in each target account. Until both are in place, the operator has nothing to federate to and no permission to update the policy.

## References

- Requires chanzuckerberg/shared-infra#11978, which must merge and apply first.
- Stacked on #1236.

The full stack, merge bottom-up:

1. #1236 the CRD schema and the design doc
2. #1237 the IAM trust policy
3. #1238 the operator running threads as pods
4. #1239 the portal
5. #1240 enabling it in rdev
6. chanzuckerberg/shared-infra#11978 the AWS identity provider and provisioner permission, which applies before #1237 merges
