### PR TITLE
feat(operator): run each agent thread as a pod with its own workspace

### DIFF
--- a/.infra/rdev/templates/rbac.yaml
+++ b/.infra/rdev/templates/rbac.yaml
@@ -92,3 +92,33 @@ subjects:
   - kind: ServiceAccount
     name: agent-operator
     namespace: {{ .Release.Namespace }}
+---
+# The operator also runs each agent's threads as pods in this namespace. That access is
+# namespaced rather than cluster-wide: the operator can create workloads only where it lives,
+# so a compromised operator cannot place pods elsewhere in the cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-operator-threads
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts", "services", "configmaps", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-operator-threads
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agent-operator-threads
+subjects:
+  - kind: ServiceAccount
+    name: agent-operator
+    namespace: {{ .Release.Namespace }}

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -7,13 +7,18 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	agentsv1 "github.com/chanzuckerberg/aws-oidc/api/v1"
+	"github.com/chanzuckerberg/aws-oidc/internal/agentpod"
 	"github.com/chanzuckerberg/aws-oidc/internal/controller"
 	awsprovider "github.com/chanzuckerberg/aws-oidc/internal/providers/aws"
 	"github.com/chanzuckerberg/aws-oidc/pkg/configmap"
@@ -30,6 +35,12 @@ const (
 	flagAWSRegion           = "aws-region"
 	flagGrantConcurrency    = "grant-concurrency"
 	flagRoleTags            = "role-tags"
+	flagClusterOIDCProvider = "cluster-oidc-provider"
+	flagAgentImage          = "agent-default-image"
+	flagAgentCommand        = "agent-default-command"
+	flagAgentStorageClass   = "agent-storage-class"
+	flagAgentStorageSize    = "agent-default-storage-size"
+	flagMaxThreadsPerAgent  = "max-threads-per-agent"
 )
 
 func init() {
@@ -44,6 +55,12 @@ func init() {
 	operatorCmd.Flags().String(flagAWSRegion, "us-east-1", "Region used for STS and IAM calls")
 	operatorCmd.Flags().Int(flagGrantConcurrency, 8, "Maximum grants of one agent provisioned in parallel")
 	operatorCmd.Flags().StringToString(flagRoleTags, nil, "Standard tags applied to every agent role (for example project=agent-registry,env=rdev,service=aws-oidc)")
+	operatorCmd.Flags().String(flagClusterOIDCProvider, "", "EKS cluster OIDC issuer without scheme (for example oidc.eks.us-west-2.amazonaws.com/id/EXAMPLE); empty means agents do not run in the cluster")
+	operatorCmd.Flags().String(flagAgentImage, "", "Container image an agent thread runs when the agent does not name one")
+	operatorCmd.Flags().StringSlice(flagAgentCommand, []string{"sleep", "infinity"}, "Command an agent thread runs when neither the agent nor its image provides a long-running entrypoint")
+	operatorCmd.Flags().String(flagAgentStorageClass, "ebs-csi-encrypted-gp3", "Storage class each agent thread's workspace is provisioned from")
+	operatorCmd.Flags().String(flagAgentStorageSize, "20Gi", "Workspace size an agent thread gets when the agent does not ask for one")
+	operatorCmd.Flags().Int(flagMaxThreadsPerAgent, 5, "Maximum threads one agent may run")
 }
 
 // operatorCmd runs the Agent controller-manager: it watches Agent custom resources and
@@ -99,6 +116,30 @@ func operatorRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("missing role-tags flag: %w", err)
 	}
+	clusterOIDCProvider, err := cmd.Flags().GetString(flagClusterOIDCProvider)
+	if err != nil {
+		return fmt.Errorf("missing cluster-oidc-provider flag: %w", err)
+	}
+	agentImage, err := cmd.Flags().GetString(flagAgentImage)
+	if err != nil {
+		return fmt.Errorf("missing agent-default-image flag: %w", err)
+	}
+	agentCommand, err := cmd.Flags().GetStringSlice(flagAgentCommand)
+	if err != nil {
+		return fmt.Errorf("missing agent-default-command flag: %w", err)
+	}
+	agentStorageClass, err := cmd.Flags().GetString(flagAgentStorageClass)
+	if err != nil {
+		return fmt.Errorf("missing agent-storage-class flag: %w", err)
+	}
+	agentStorageSize, err := cmd.Flags().GetString(flagAgentStorageSize)
+	if err != nil {
+		return fmt.Errorf("missing agent-default-storage-size flag: %w", err)
+	}
+	maxThreads, err := cmd.Flags().GetInt(flagMaxThreadsPerAgent)
+	if err != nil {
+		return fmt.Errorf("missing max-threads-per-agent flag: %w", err)
+	}
 
 	// Route controller-runtime's logr logging through the repo's slog logger set up in
 	// PersistentPreRunE, so the operator logs the same way as the rest of the binary.
@@ -126,6 +167,7 @@ func operatorRun(cmd *cobra.Command, args []string) error {
 		LeaderElectionNamespace: namespace,
 		HealthProbeBindAddress:  healthAddr,
 		Metrics:                 metricsserver.Options{BindAddress: "0"},
+		Cache:                   cache.Options{ByObject: threadObjectCache(namespace)},
 	})
 	if err != nil {
 		return fmt.Errorf("creating manager: %w", err)
@@ -154,16 +196,34 @@ func operatorRun(cmd *cobra.Command, args []string) error {
 	// AWS is the only provider today. Additional providers are appended here as they are
 	// implemented; the reconciler dispatches each grant to the one that handles it.
 	awsProvider := awsprovider.NewProvider(awsprovider.Config{
-		IssuerHost:         issuerHost,
-		OktaAppClientID:    oktaAppClientID,
-		BoundaryPolicyName: boundaryPolicyName,
-		DefaultTags:        roleTags,
+		IssuerHost:          issuerHost,
+		OktaAppClientID:     oktaAppClientID,
+		BoundaryPolicyName:  boundaryPolicyName,
+		DefaultTags:         roleTags,
+		ClusterOIDCProvider: clusterOIDCProvider,
+		PodNamespace:        namespace,
 	}, clientFactory)
+
+	// Threads only run where the cluster's OIDC issuer is configured, since without it their
+	// pods have no way to assume the agent's roles.
+	var threads controller.ThreadReconciler
+	if clusterOIDCProvider != "" {
+		threads = agentpod.New(mgr.GetClient(), mgr.GetScheme(), agentpod.Config{
+			Namespace:          namespace,
+			DefaultImage:       agentImage,
+			DefaultCommand:     agentCommand,
+			StorageClass:       agentStorageClass,
+			DefaultStorageSize: agentStorageSize,
+			Region:             awsRegion,
+			MaxThreads:         maxThreads,
+		})
+	}
 
 	reconciler := &controller.AgentReconciler{
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),
 		Providers:           []controller.Provider{awsProvider},
+		Threads:             threads,
 		MaxConcurrentGrants: grantConcurrency,
 	}
 	err = reconciler.SetupWithManager(mgr)
@@ -176,4 +236,19 @@ func operatorRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("running manager: %w", err)
 	}
 	return nil
+}
+
+// threadObjectCache confines the caches for the objects an agent's threads are made of to the
+// operator's own namespace. Agents are still watched cluster-wide, but the operator's access to
+// workloads is deliberately namespaced, so a cluster-wide informer for these would be refused
+// and the controller would never start.
+func threadObjectCache(namespace string) map[client.Object]cache.ByObject {
+	own := cache.ByObject{Namespaces: map[string]cache.Config{namespace: {}}}
+	return map[client.Object]cache.ByObject{
+		&appsv1.StatefulSet{}:           own,
+		&corev1.ServiceAccount{}:        own,
+		&corev1.Service{}:               own,
+		&corev1.ConfigMap{}:             own,
+		&corev1.PersistentVolumeClaim{}: own,
+	}
 }

--- a/internal/agentpod/agentpod.go
+++ b/internal/agentpod/agentpod.go
@@ -1,0 +1,334 @@
+// Package agentpod runs an agent's threads in the cluster. An agent is not a single session:
+// a person runs several threads of the same agent at once, so each thread gets its own pod and
+// its own persistent workspace, while sharing the agent's access.
+//
+// Per agent it maintains a headless Service (so each thread pod has a stable DNS name) and a
+// ConfigMap holding the rendered AWS config. Per thread it maintains a ServiceAccount, a
+// StatefulSet, and the EBS-backed workspace the StatefulSet claims. The thread's pod exchanges
+// its projected service account token for the agent's IAM roles, which trust the cluster's
+// OIDC issuer for exactly these service accounts.
+package agentpod
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	agentsv1 "github.com/chanzuckerberg/aws-oidc/api/v1"
+)
+
+const (
+	// LabelAgent and LabelThread identify which agent and thread an object belongs to. The
+	// reconciler selects on them to find objects whose thread is gone from the spec.
+	LabelAgent  = "agents.czi.team/agent"
+	LabelThread = "agents.czi.team/thread"
+
+	// labelManagedBy marks the objects this package owns.
+	labelManagedBy = "app.kubernetes.io/managed-by"
+	managedByValue = "aws-oidc-agent-operator"
+
+	// tokenMountPath is where the projected service account token is mounted, and
+	// tokenFilePath is the file the AWS SDK reads it from. IRSA's webhook does not inject a
+	// token without a role annotation on the service account, and an agent's roles are
+	// per-grant rather than one per service account, so the volume is declared explicitly.
+	tokenMountPath = "/var/run/secrets/agents.czi.team/serviceaccount"
+	tokenFilePath  = tokenMountPath + "/token"
+
+	// awsConfigMountPath is where the rendered AWS config is mounted, and awsConfigFilePath is
+	// what AWS_CONFIG_FILE points at.
+	awsConfigMountPath = "/etc/aws"
+	awsConfigFilePath  = awsConfigMountPath + "/config"
+
+	// workspaceMountPath is the thread's persistent working directory.
+	workspaceMountPath = "/workspace"
+
+	// tokenAudience is the audience STS requires on a projected token used for web identity.
+	tokenAudience = "sts.amazonaws.com"
+
+	// tokenExpirationSeconds is the projected token's lifetime. The kubelet rotates it at 80%
+	// of this, and the AWS SDK re-reads the file on each refresh.
+	tokenExpirationSeconds int64 = 3600
+
+	agentContainerName = "agent"
+	awsConfigVolume    = "aws-config"
+	tokenVolume        = "aws-token"
+)
+
+// Config is the operator-level policy for running agent threads, the same for every agent.
+type Config struct {
+	// Namespace is where the threads run. It is the operator's own namespace, so owner
+	// references garbage-collect an agent's objects when the agent is deleted.
+	Namespace string
+	// DefaultImage is the agent image used when spec.runtime.image is unset.
+	DefaultImage string
+	// DefaultCommand is the command an agent thread runs when neither the agent nor the image
+	// provides a long-running entrypoint. Without it a base image whose entrypoint exits
+	// leaves the pod crash-looping.
+	DefaultCommand []string
+	// StorageClass is the storage class each thread's workspace is provisioned from.
+	StorageClass string
+	// DefaultStorageSize is the workspace size used when spec.runtime.storage is unset.
+	DefaultStorageSize string
+	// Region is the AWS region written into the rendered AWS config.
+	Region string
+	// MaxThreads bounds how many threads one agent may run, so a single Agent write cannot
+	// ask for an unbounded number of pods and volumes.
+	MaxThreads int
+}
+
+// Reconciler drives an agent's threads toward the spec.
+type Reconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	Config
+}
+
+// New returns a Reconciler with defaults applied.
+func New(c client.Client, scheme *runtime.Scheme, cfg Config) *Reconciler {
+	if cfg.StorageClass == "" {
+		cfg.StorageClass = "ebs-csi-encrypted-gp3"
+	}
+	if cfg.DefaultStorageSize == "" {
+		cfg.DefaultStorageSize = "20Gi"
+	}
+	if cfg.Region == "" {
+		cfg.Region = "us-west-2"
+	}
+	if cfg.MaxThreads <= 0 {
+		cfg.MaxThreads = defaultMaxThreads
+	}
+	return &Reconciler{Client: c, Scheme: scheme, Config: cfg}
+}
+
+// defaultMaxThreads is the per-agent thread ceiling when none is configured.
+const defaultMaxThreads = 5
+
+// Reconcile brings the agent's threads in line with its spec and returns their statuses,
+// aligned with spec.threads. The grant statuses come from the AWS provider and carry the role
+// ARNs the pods' AWS config needs, so this runs after the grants are reconciled.
+//
+// An agent with no runtime has no threads, so everything the agent owns is pruned.
+func (r *Reconciler) Reconcile(ctx context.Context, agent *agentsv1.Agent) ([]agentsv1.ThreadStatus, error) {
+	if agent.Spec.Runtime == nil {
+		err := r.pruneThreads(ctx, agent, nil)
+		if err != nil {
+			return nil, err
+		}
+		return nil, r.pruneShared(ctx, agent)
+	}
+
+	err := r.ensureService(ctx, agent)
+	if err != nil {
+		return nil, err
+	}
+	err = r.ensureAWSConfig(ctx, agent)
+	if err != nil {
+		return nil, err
+	}
+
+	threads := agent.Spec.Threads
+	statuses := make([]agentsv1.ThreadStatus, 0, len(threads))
+	keep := make(map[string]bool, len(threads))
+	var errs []error
+
+	for i := range threads {
+		thread := threads[i]
+
+		if i >= r.MaxThreads {
+			statuses = append(statuses, agentsv1.ThreadStatus{
+				Name:    thread.Name,
+				State:   agentsv1.ThreadStateFailed,
+				Message: fmt.Sprintf("agent is limited to %d threads", r.MaxThreads),
+			})
+			continue
+		}
+		keep[thread.Name] = true
+
+		status, err := r.reconcileThread(ctx, agent, thread)
+		if err != nil {
+			status.State = agentsv1.ThreadStateFailed
+			status.Message = err.Error()
+			errs = append(errs, err)
+		}
+		statuses = append(statuses, status)
+	}
+
+	// Prune after reconciling, so a thread that failed to come up is not also torn down.
+	err = r.pruneThreads(ctx, agent, keep)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	return statuses, errors.Join(errs...)
+}
+
+// reconcileThread ensures one thread's service account, workload, and workspace, then reports
+// what it found.
+func (r *Reconciler) reconcileThread(ctx context.Context, agent *agentsv1.Agent, thread agentsv1.AgentThread) (agentsv1.ThreadStatus, error) {
+	status := agentsv1.ThreadStatus{
+		Name:               thread.Name,
+		ServiceAccountName: agent.ThreadServiceAccountName(thread.Name),
+		StatefulSetName:    agent.ThreadStatefulSetName(thread.Name),
+		WorkspaceClaimName: agent.ThreadWorkspaceClaimName(thread.Name),
+		State:              agentsv1.ThreadStatePending,
+	}
+
+	err := r.ensureServiceAccount(ctx, agent, thread)
+	if err != nil {
+		return status, err
+	}
+
+	// A storage resize has to be applied to the claim before the workload, since a
+	// StatefulSet's volume claim template is immutable and the claim is what actually grows.
+	err = r.ensureWorkspaceSize(ctx, agent, thread)
+	if err != nil {
+		return status, err
+	}
+
+	set, err := r.ensureStatefulSet(ctx, agent, thread)
+	if err != nil {
+		return status, err
+	}
+
+	err = r.adoptWorkspace(ctx, agent, thread)
+	if err != nil {
+		return status, err
+	}
+
+	status.ReadyReplicas = set.Status.ReadyReplicas
+	switch {
+	case thread.Suspended:
+		status.State = agentsv1.ThreadStateSuspended
+	case set.Status.ReadyReplicas > 0:
+		status.State = agentsv1.ThreadStateRunning
+	}
+	return status, nil
+}
+
+func (r *Reconciler) ensureService(ctx context.Context, agent *agentsv1.Agent) error {
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      agent.ServiceName(),
+		Namespace: r.Namespace,
+	}}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, func() error {
+		service.Labels = agentLabels(agent)
+		service.Spec.ClusterIP = corev1.ClusterIPNone
+		service.Spec.Selector = agentLabels(agent)
+		// The threads serve no traffic yet. A port is declared anyway because a headless
+		// service with no ports publishes no DNS records for its pods.
+		service.Spec.Ports = []corev1.ServicePort{{Name: "agent", Port: 8080}}
+		return controllerutil.SetControllerReference(agent, service, r.Scheme)
+	})
+	if err != nil {
+		return fmt.Errorf("ensuring service %s: %w", service.Name, err)
+	}
+	return nil
+}
+
+// ensureAWSConfig writes the agent's rendered AWS config. Every thread mounts the same one,
+// since threads differ in workspace, not in access.
+func (r *Reconciler) ensureAWSConfig(ctx context.Context, agent *agentsv1.Agent) error {
+	rendered, err := r.renderAWSConfig(agent)
+	if err != nil {
+		return err
+	}
+
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      agent.AWSConfigMapName(),
+		Namespace: r.Namespace,
+	}}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, configMap, func() error {
+		configMap.Labels = agentLabels(agent)
+		configMap.Data = map[string]string{"config": rendered}
+		return controllerutil.SetControllerReference(agent, configMap, r.Scheme)
+	})
+	if err != nil {
+		return fmt.Errorf("ensuring config map %s: %w", configMap.Name, err)
+	}
+	return nil
+}
+
+// ensureServiceAccount creates the identity the thread's pod runs as. Its name is what the
+// agent's IAM roles trust, so the pod can assume them with its projected token.
+func (r *Reconciler) ensureServiceAccount(ctx context.Context, agent *agentsv1.Agent, thread agentsv1.AgentThread) error {
+	account := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name:      agent.ThreadServiceAccountName(thread.Name),
+		Namespace: r.Namespace,
+	}}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, account, func() error {
+		account.Labels = threadLabels(agent, thread.Name)
+		return controllerutil.SetControllerReference(agent, account, r.Scheme)
+	})
+	if err != nil {
+		return fmt.Errorf("ensuring service account %s: %w", account.Name, err)
+	}
+	return nil
+}
+
+// agentLabels identifies every object belonging to one agent.
+func agentLabels(agent *agentsv1.Agent) map[string]string {
+	return map[string]string{
+		LabelAgent:     agent.Name,
+		labelManagedBy: managedByValue,
+	}
+}
+
+// threadLabels identifies the objects belonging to one thread of one agent.
+func threadLabels(agent *agentsv1.Agent, thread string) map[string]string {
+	labels := agentLabels(agent)
+	labels[LabelThread] = thread
+	return labels
+}
+
+// storageSize is the workspace size the agent asks for, falling back to the operator default.
+func (r *Reconciler) storageSize(agent *agentsv1.Agent) (resource.Quantity, error) {
+	size := r.DefaultStorageSize
+	if agent.Spec.Runtime.Storage != nil && agent.Spec.Runtime.Storage.Size != "" {
+		size = agent.Spec.Runtime.Storage.Size
+	}
+	quantity, err := resource.ParseQuantity(size)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("parsing storage size %q: %w", size, err)
+	}
+	return quantity, nil
+}
+
+func (r *Reconciler) storageClass(agent *agentsv1.Agent) string {
+	if agent.Spec.Runtime.Storage != nil && agent.Spec.Runtime.Storage.StorageClassName != "" {
+		return agent.Spec.Runtime.Storage.StorageClassName
+	}
+	return r.StorageClass
+}
+
+func (r *Reconciler) image(agent *agentsv1.Agent) string {
+	if agent.Spec.Runtime.Image != "" {
+		return agent.Spec.Runtime.Image
+	}
+	return r.DefaultImage
+}
+
+func (r *Reconciler) command(agent *agentsv1.Agent) []string {
+	if len(agent.Spec.Runtime.Command) > 0 {
+		return agent.Spec.Runtime.Command
+	}
+	return r.DefaultCommand
+}
+
+// ignoreNotFound treats an already-deleted object as success, so pruning is idempotent.
+func ignoreNotFound(err error) error {
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/internal/agentpod/agentpod_test.go
+++ b/internal/agentpod/agentpod_test.go
@@ -1,0 +1,345 @@
+package agentpod
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agentsv1 "github.com/chanzuckerberg/aws-oidc/api/v1"
+)
+
+const testNamespace = "argus-aws-oidc-rdev"
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, agentsv1.AddToScheme(scheme))
+	return scheme
+}
+
+func testReconciler(t *testing.T, objects ...client.Object) (*Reconciler, client.Client) {
+	t.Helper()
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	return New(c, scheme, Config{
+		Namespace:    testNamespace,
+		DefaultImage: "ubuntu:24.04",
+	}), c
+}
+
+// testAgent is an agent with one provisioned grant and two threads, one of them suspended.
+func testAgent() *agentsv1.Agent {
+	agent := &agentsv1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bot",
+			Namespace: testNamespace,
+			UID:       "0f8fad5b-d9cb-469f-a165-70867728950e",
+		},
+		Spec: agentsv1.AgentSpec{
+			Owner:      "00uSUB123",
+			OwnerEmail: "jheath@chanzuckerberg.com",
+			Grants: []agentsv1.Grant{{AWS: &agentsv1.AWSGrant{
+				AccountID:    "111111111111",
+				AccountAlias: "playground",
+				RoleARN:      "arn:aws:iam::111111111111:role/readonly",
+				RoleName:     "readonly",
+			}}},
+			Runtime: &agentsv1.AgentRuntime{},
+			Threads: []agentsv1.AgentThread{
+				{Name: "main"},
+				{Name: "review", Suspended: true},
+			},
+		},
+		Status: agentsv1.AgentStatus{
+			Grants: []agentsv1.GrantStatus{{
+				Provider: "aws",
+				State:    agentsv1.GrantStateProvisioned,
+				AWS: &agentsv1.AWSGrantStatus{
+					AccountID: "111111111111",
+					RoleARN:   "arn:aws:iam::111111111111:role/agents/jheath-agent-bot-readonly",
+				},
+			}},
+		},
+	}
+	return agent
+}
+
+func TestReconcileCreatesOneStatefulSetPerThread(t *testing.T) {
+	ctx := context.Background()
+	agent := testAgent()
+	r, c := testReconciler(t, agent)
+
+	statuses, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+	require.Len(t, statuses, 2)
+
+	// A thread with no ready pod yet is pending; a suspended one reports suspended rather than
+	// waiting forever on a pod that will not arrive.
+	require.Equal(t, agentsv1.ThreadStatePending, statuses[0].State)
+	require.Equal(t, agentsv1.ThreadStateSuspended, statuses[1].State)
+
+	sets := &appsv1.StatefulSetList{}
+	require.NoError(t, c.List(ctx, sets, client.InNamespace(testNamespace)))
+	require.Len(t, sets.Items, 2)
+
+	byName := map[string]appsv1.StatefulSet{}
+	for _, set := range sets.Items {
+		byName[set.Name] = set
+	}
+
+	main := byName["agent-bot-main"]
+	require.Equal(t, int32(1), *main.Spec.Replicas)
+	require.Equal(t, "agent-bot", main.Spec.ServiceName)
+	// Each thread runs as its own service account, which is what the role trust matches and
+	// what makes a thread's AWS activity attributable.
+	require.Equal(t, "agent-0f8fad5bd9cb-main", main.Spec.Template.Spec.ServiceAccountName)
+
+	// Suspended means zero replicas, not deleted, so the workspace survives.
+	require.Equal(t, int32(0), *byName["agent-bot-review"].Spec.Replicas)
+
+	accounts := &corev1.ServiceAccountList{}
+	require.NoError(t, c.List(ctx, accounts, client.InNamespace(testNamespace)))
+	require.Len(t, accounts.Items, 2)
+}
+
+func TestReconcileMountsTokenAndAWSConfig(t *testing.T) {
+	ctx := context.Background()
+	agent := testAgent()
+	r, c := testReconciler(t, agent)
+
+	_, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+
+	set := &appsv1.StatefulSet{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "agent-bot-main"}, set))
+
+	pod := set.Spec.Template.Spec
+	var projected *corev1.ServiceAccountTokenProjection
+	for _, volume := range pod.Volumes {
+		if volume.Projected != nil && len(volume.Projected.Sources) == 1 {
+			projected = volume.Projected.Sources[0].ServiceAccountToken
+		}
+	}
+	require.NotNil(t, projected, "the token volume is explicit because IRSA's webhook does not inject one")
+	require.Equal(t, "sts.amazonaws.com", projected.Audience)
+
+	// The projected token is the pod's only credential, so agent code cannot reach the
+	// Kubernetes API.
+	require.False(t, *pod.AutomountServiceAccountToken)
+	require.False(t, *pod.Containers[0].SecurityContext.AllowPrivilegeEscalation)
+
+	env := map[string]string{}
+	for _, e := range pod.Containers[0].Env {
+		env[e.Name] = e.Value
+	}
+	require.Equal(t, awsConfigFilePath, env["AWS_CONFIG_FILE"])
+	require.Equal(t, "agent-scoped", env["AWS_PROFILE"])
+	require.Equal(t, "main", env["AGENT_THREAD"])
+
+	// The rendered config points every profile at the projected token, and all threads of the
+	// agent share it.
+	configMap := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "agent-bot-aws-config"}, configMap))
+	require.Contains(t, configMap.Data["config"], "web_identity_token_file = "+tokenFilePath)
+	require.Contains(t, configMap.Data["config"], "arn:aws:iam::111111111111:role/agents/jheath-agent-bot-readonly")
+	require.Contains(t, configMap.Data["config"], "[profile agent-scoped]")
+	// Profile names come from the same builder the laptop rendering uses, so a prompt written
+	// against a laptop config finds the same profile in a pod.
+	require.Contains(t, configMap.Data["config"], "[profile playground-agents-jheath-agent-bot-readonly]")
+	// Sessions are named after the agent, so CloudTrail says which agent acted.
+	require.Regexp(t, `role_session_name\s+= agent-bot`, configMap.Data["config"])
+}
+
+func TestReconcileIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	agent := testAgent()
+	r, c := testReconciler(t, agent)
+
+	_, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+
+	before := &appsv1.StatefulSet{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "agent-bot-main"}, before))
+
+	_, err = r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+
+	after := &appsv1.StatefulSet{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "agent-bot-main"}, after))
+	require.Equal(t, before.ResourceVersion, after.ResourceVersion, "a steady-state resync must not write")
+}
+
+// Removing a thread from the spec has to delete its objects. Owner references do not cover
+// this, because the agent itself still exists.
+func TestReconcilePrunesRemovedThread(t *testing.T) {
+	ctx := context.Background()
+	agent := testAgent()
+	r, c := testReconciler(t, agent)
+
+	_, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+
+	agent.Spec.Threads = []agentsv1.AgentThread{{Name: "main"}}
+	statuses, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+
+	sets := &appsv1.StatefulSetList{}
+	require.NoError(t, c.List(ctx, sets, client.InNamespace(testNamespace)))
+	require.Len(t, sets.Items, 1)
+	require.Equal(t, "agent-bot-main", sets.Items[0].Name)
+
+	accounts := &corev1.ServiceAccountList{}
+	require.NoError(t, c.List(ctx, accounts, client.InNamespace(testNamespace), client.MatchingLabels{LabelAgent: "bot"}))
+	require.Len(t, accounts.Items, 1)
+}
+
+// Disabling the runtime removes everything, including the objects the threads shared.
+func TestReconcileWithoutRuntimeRemovesEverything(t *testing.T) {
+	ctx := context.Background()
+	agent := testAgent()
+	r, c := testReconciler(t, agent)
+
+	_, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+
+	agent.Spec.Runtime = nil
+	statuses, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+	require.Empty(t, statuses)
+
+	sets := &appsv1.StatefulSetList{}
+	require.NoError(t, c.List(ctx, sets, client.InNamespace(testNamespace)))
+	require.Empty(t, sets.Items)
+
+	services := &corev1.ServiceList{}
+	require.NoError(t, c.List(ctx, services, client.InNamespace(testNamespace)))
+	require.Empty(t, services.Items)
+
+	configMaps := &corev1.ConfigMapList{}
+	require.NoError(t, c.List(ctx, configMaps, client.InNamespace(testNamespace)))
+	require.Empty(t, configMaps.Items)
+}
+
+func TestReconcileRefusesThreadsBeyondTheLimit(t *testing.T) {
+	ctx := context.Background()
+	agent := testAgent()
+	agent.Spec.Threads = []agentsv1.AgentThread{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+
+	r, c := testReconciler(t, agent)
+	r.MaxThreads = 2
+
+	statuses, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+	require.Len(t, statuses, 3)
+	require.Equal(t, agentsv1.ThreadStateFailed, statuses[2].State)
+	require.Contains(t, statuses[2].Message, "limited to 2 threads")
+
+	sets := &appsv1.StatefulSetList{}
+	require.NoError(t, c.List(ctx, sets, client.InNamespace(testNamespace)))
+	require.Len(t, sets.Items, 2)
+}
+
+// A StatefulSet's volume claim template is immutable, so growing the workspace means patching
+// the claim and recreating the set with its pods orphaned.
+func TestWorkspaceGrowsAndRecreatesTheStatefulSet(t *testing.T) {
+	ctx := context.Background()
+	agent := testAgent()
+	agent.Spec.Threads = []agentsv1.AgentThread{{Name: "main"}}
+	agent.Spec.Runtime.Storage = &agentsv1.AgentStorage{Size: "20Gi"}
+
+	r, c := testReconciler(t, agent)
+	_, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+
+	// The fake client does not run the StatefulSet controller, so stand in for the claim it
+	// would have created from the template.
+	claim := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "workspace-agent-bot-main-0", Namespace: testNamespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("20Gi")},
+			},
+		},
+	}
+	require.NoError(t, c.Create(ctx, claim))
+
+	agent.Spec.Runtime.Storage.Size = "50Gi"
+	_, err = r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+
+	grown := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(claim), grown))
+	require.Equal(t, "50Gi", grown.Spec.Resources.Requests.Storage().String())
+	// The claim is owned by the agent, so deleting the agent releases the EBS volume even
+	// though the StatefulSet was replaced.
+	require.Len(t, grown.OwnerReferences, 1)
+	require.Equal(t, "bot", grown.OwnerReferences[0].Name)
+
+	set := &appsv1.StatefulSet{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "agent-bot-main"}, set))
+	require.Equal(t, "50Gi", set.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests.Storage().String())
+}
+
+// A smaller request cannot be applied to a provisioned volume, so it is ignored rather than
+// failing the thread.
+func TestWorkspaceIgnoresShrink(t *testing.T) {
+	ctx := context.Background()
+	agent := testAgent()
+	agent.Spec.Threads = []agentsv1.AgentThread{{Name: "main"}}
+	agent.Spec.Runtime.Storage = &agentsv1.AgentStorage{Size: "10Gi"}
+
+	claim := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workspace-agent-bot-main-0",
+			Namespace: testNamespace,
+			Labels:    map[string]string{LabelAgent: "bot", LabelThread: "main"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("20Gi")},
+			},
+		},
+	}
+
+	r, c := testReconciler(t, agent, claim)
+	_, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+
+	unchanged := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(claim), unchanged))
+	require.Equal(t, "20Gi", unchanged.Spec.Resources.Requests.Storage().String())
+}
+
+func TestReconcileReportsRunningThread(t *testing.T) {
+	ctx := context.Background()
+	agent := testAgent()
+	agent.Spec.Threads = []agentsv1.AgentThread{{Name: "main"}}
+
+	r, c := testReconciler(t, agent)
+	_, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+
+	set := &appsv1.StatefulSet{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "agent-bot-main"}, set))
+	set.Status.ReadyReplicas = 1
+	require.NoError(t, c.Status().Update(ctx, set))
+
+	statuses, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+	require.Equal(t, agentsv1.ThreadStateRunning, statuses[0].State)
+	require.Equal(t, int32(1), statuses[0].ReadyReplicas)
+}

--- a/internal/agentpod/awsconfig.go
+++ b/internal/agentpod/awsconfig.go
@@ -1,0 +1,80 @@
+package agentpod
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/ini.v1"
+
+	agentsv1 "github.com/chanzuckerberg/aws-oidc/api/v1"
+	"github.com/chanzuckerberg/aws-oidc/internal/agentconfig"
+	awsconfigclient "github.com/chanzuckerberg/aws-oidc/pkg/aws_config_client"
+)
+
+// renderAWSConfig builds the AWS config file the agent's pods mount. It is the in-cluster
+// counterpart to the laptop rendering in pkg/aws_config_client: same profile names, but the
+// credentials come from the pod's projected service account token exchanged with STS rather
+// than from a credential_process running aws-oidc. Profile names match so a prompt or script
+// that works on a laptop works in a pod.
+//
+// It returns an empty string when the agent has no provisioned grants, which is how a pod
+// waiting on its roles is distinguished from one that has them.
+func (r *Reconciler) renderAWSConfig(agent *agentsv1.Agent) (string, error) {
+	// The Okta client id and issuer only matter to the laptop rendering, which mints tokens
+	// through Okta. In the cluster the token comes from Kubernetes, so they are left empty.
+	configs := agentconfig.Build([]agentsv1.Agent{*agent}, "", "")
+	if len(configs) == 0 {
+		return "", nil
+	}
+	profiles := configs[0].Profiles
+
+	out := ini.Empty()
+	for i := range profiles {
+		profile := profiles[i]
+
+		err := r.addProfile(out, awsconfigclient.AgentProfileName(profile), profile.RoleARN, agent.Name)
+		if err != nil {
+			return "", err
+		}
+
+		// The first grant doubles as the default profile so a bare `aws` call works, matching
+		// what the laptop rendering does.
+		if i == 0 {
+			err = r.addProfile(out, awsconfigclient.AgentScopedProfile, profile.RoleARN, agent.Name)
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+
+	var rendered strings.Builder
+	_, err := out.WriteTo(&rendered)
+	if err != nil {
+		return "", fmt.Errorf("rendering aws config: %w", err)
+	}
+	return rendered.String(), nil
+}
+
+func (r *Reconciler) addProfile(out *ini.File, name, roleARN, agentName string) error {
+	section, err := out.NewSection("profile " + name)
+	if err != nil {
+		return fmt.Errorf("creating profile %s: %w", name, err)
+	}
+	section.Key(awsconfigclient.AWSConfigSectionOutput).SetValue("json")
+	section.Key(awsconfigclient.AWSConfigSectionRegion).SetValue(r.Region)
+	section.Key("role_arn").SetValue(roleARN)
+	section.Key("web_identity_token_file").SetValue(tokenFilePath)
+	// Naming the session after the agent is what makes CloudTrail readable. Which thread acted
+	// is still recoverable from the token subject STS records.
+	section.Key("role_session_name").SetValue(sessionName(agentName))
+	return nil
+}
+
+// sessionName fits an agent name into the 64 characters STS allows for a session name.
+func sessionName(agentName string) string {
+	name := "agent-" + agentName
+	if len(name) > 64 {
+		return name[:64]
+	}
+	return name
+}

--- a/internal/agentpod/prune.go
+++ b/internal/agentpod/prune.go
@@ -1,0 +1,99 @@
+package agentpod
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	agentsv1 "github.com/chanzuckerberg/aws-oidc/api/v1"
+)
+
+// pruneThreads deletes the objects of threads the agent no longer declares. Owner references
+// do not cover this: the agent still exists, so nothing garbage-collects a thread that was
+// merely removed from the spec. The workspace is deleted explicitly, since that is what
+// releases the EBS volume.
+//
+// keep is the set of thread names to preserve; a nil or empty set removes every thread.
+func (r *Reconciler) pruneThreads(ctx context.Context, agent *agentsv1.Agent, keep map[string]bool) error {
+	log := logf.FromContext(ctx)
+
+	inAgent := client.MatchingLabels{LabelAgent: agent.Name}
+	inNamespace := client.InNamespace(r.Namespace)
+
+	sets := &appsv1.StatefulSetList{}
+	err := r.List(ctx, sets, inNamespace, inAgent)
+	if err != nil {
+		return fmt.Errorf("listing statefulsets of agent %s: %w", agent.Name, err)
+	}
+
+	accounts := &corev1.ServiceAccountList{}
+	err = r.List(ctx, accounts, inNamespace, inAgent)
+	if err != nil {
+		return fmt.Errorf("listing service accounts of agent %s: %w", agent.Name, err)
+	}
+
+	claims := &corev1.PersistentVolumeClaimList{}
+	err = r.List(ctx, claims, inNamespace, inAgent)
+	if err != nil {
+		return fmt.Errorf("listing workspaces of agent %s: %w", agent.Name, err)
+	}
+
+	var (
+		stale []client.Object
+		errs  []error
+	)
+	for i := range sets.Items {
+		if !keep[sets.Items[i].Labels[LabelThread]] {
+			stale = append(stale, &sets.Items[i])
+		}
+	}
+	for i := range accounts.Items {
+		if !keep[accounts.Items[i].Labels[LabelThread]] {
+			stale = append(stale, &accounts.Items[i])
+		}
+	}
+	for i := range claims.Items {
+		if !keep[claims.Items[i].Labels[LabelThread]] {
+			stale = append(stale, &claims.Items[i])
+		}
+	}
+
+	for _, obj := range stale {
+		log.Info("pruning object of removed agent thread",
+			"agent", agent.Name,
+			"thread", obj.GetLabels()[LabelThread],
+			"kind", fmt.Sprintf("%T", obj),
+			"name", obj.GetName())
+
+		err = ignoreNotFound(r.Delete(ctx, obj))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("pruning %s: %w", obj.GetName(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// pruneShared removes the objects an agent's threads share, for an agent that no longer runs
+// in the cluster at all. They are keyed on kind rather than labels, so a thread's objects are
+// never caught by this.
+func (r *Reconciler) pruneShared(ctx context.Context, agent *agentsv1.Agent) error {
+	shared := []client.Object{
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: agent.ServiceName(), Namespace: r.Namespace}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: agent.AWSConfigMapName(), Namespace: r.Namespace}},
+	}
+
+	var errs []error
+	for _, obj := range shared {
+		err := ignoreNotFound(r.Delete(ctx, obj))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("pruning %s: %w", obj.GetName(), err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/agentpod/statefulset.go
+++ b/internal/agentpod/statefulset.go
@@ -1,0 +1,337 @@
+package agentpod
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	agentsv1 "github.com/chanzuckerberg/aws-oidc/api/v1"
+	awsconfigclient "github.com/chanzuckerberg/aws-oidc/pkg/aws_config_client"
+)
+
+// ensureStatefulSet creates or updates the workload running one thread and returns its current
+// state. A thread is one replica: the workspace is a ReadWriteOnce EBS volume, and two pods
+// sharing a working directory is not what a thread is.
+//
+// A StatefulSet's volume claim template is immutable, so when the requested workspace size
+// changes the set is recreated with its pods orphaned, which leaves the running pod and the
+// resized claim in place.
+func (r *Reconciler) ensureStatefulSet(ctx context.Context, agent *agentsv1.Agent, thread agentsv1.AgentThread) (*appsv1.StatefulSet, error) {
+	desired, err := r.statefulSet(agent, thread)
+	if err != nil {
+		return nil, err
+	}
+
+	existing := &appsv1.StatefulSet{}
+	err = r.Get(ctx, client.ObjectKeyFromObject(desired), existing)
+	switch {
+	case apierrors.IsNotFound(err):
+		err = r.Create(ctx, desired)
+		if err != nil {
+			return nil, fmt.Errorf("creating statefulset %s: %w", desired.Name, err)
+		}
+		return desired, nil
+	case err != nil:
+		return nil, fmt.Errorf("getting statefulset %s: %w", desired.Name, err)
+	}
+
+	if claimTemplatesDiffer(existing, desired) {
+		err = r.recreateOrphaned(ctx, existing, desired)
+		if err != nil {
+			return nil, err
+		}
+		return desired, nil
+	}
+
+	// Carry over the fields the API server defaults or the StatefulSet controller owns, so the
+	// update is limited to what this reconciler actually manages.
+	updated := existing.DeepCopy()
+	updated.Labels = desired.Labels
+	updated.Spec.Replicas = desired.Spec.Replicas
+	updated.Spec.Template = desired.Spec.Template
+
+	if equalStatefulSets(existing, updated) {
+		return existing, nil
+	}
+
+	err = r.Update(ctx, updated)
+	if err != nil {
+		return nil, fmt.Errorf("updating statefulset %s: %w", desired.Name, err)
+	}
+	return updated, nil
+}
+
+// recreateOrphaned replaces a StatefulSet whose immutable volume claim template changed. The
+// delete orphans its dependents, so the pod keeps running and the workspace claim survives to
+// be adopted by the replacement.
+func (r *Reconciler) recreateOrphaned(ctx context.Context, existing, desired *appsv1.StatefulSet) error {
+	orphan := metav1.DeletePropagationOrphan
+	err := r.Delete(ctx, existing, &client.DeleteOptions{PropagationPolicy: &orphan})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting statefulset %s for workspace resize: %w", existing.Name, err)
+	}
+
+	err = r.Create(ctx, desired)
+	if err != nil {
+		return fmt.Errorf("recreating statefulset %s for workspace resize: %w", desired.Name, err)
+	}
+	return nil
+}
+
+func (r *Reconciler) statefulSet(agent *agentsv1.Agent, thread agentsv1.AgentThread) (*appsv1.StatefulSet, error) {
+	size, err := r.storageSize(agent)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := threadLabels(agent, thread.Name)
+	replicas := int32(1)
+	if thread.Suspended {
+		replicas = 0
+	}
+
+	set := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agent.ThreadStatefulSetName(thread.Name),
+			Namespace: r.Namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    &replicas,
+			ServiceName: agent.ServiceName(),
+			Selector:    &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec:       r.podSpec(agent, thread),
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   agentsv1.WorkspaceVolumeName,
+					Labels: labels,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					StorageClassName: ptr(r.storageClass(agent)),
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: size},
+					},
+				},
+			}},
+		},
+	}
+
+	err = controllerutil.SetControllerReference(agent, set, r.Scheme)
+	if err != nil {
+		return nil, fmt.Errorf("setting owner on statefulset %s: %w", set.Name, err)
+	}
+	return set, nil
+}
+
+// podSpec is the thread's pod: the agent container, its workspace, the shared AWS config, and
+// the projected token it exchanges for the agent's roles.
+func (r *Reconciler) podSpec(agent *agentsv1.Agent, thread agentsv1.AgentThread) corev1.PodSpec {
+	runtime := agent.Spec.Runtime
+
+	return corev1.PodSpec{
+		ServiceAccountName: agent.ThreadServiceAccountName(thread.Name),
+		NodeSelector:       runtime.NodeSelector,
+		// The pod's only credential is the token projected below, minted for STS. Leaving the
+		// default Kubernetes API token out means agent code cannot talk to the cluster at all.
+		AutomountServiceAccountToken: ptr(false),
+		SecurityContext: &corev1.PodSecurityContext{
+			SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		},
+		Containers: []corev1.Container{{
+			Name:       agentContainerName,
+			Image:      r.image(agent),
+			Command:    r.command(agent),
+			Args:       runtime.Args,
+			Resources:  runtime.Resources,
+			WorkingDir: workspaceMountPath,
+			Env:        r.env(agent, thread),
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr(false),
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: agentsv1.WorkspaceVolumeName, MountPath: workspaceMountPath},
+				{Name: awsConfigVolume, MountPath: awsConfigMountPath, ReadOnly: true},
+				{Name: tokenVolume, MountPath: tokenMountPath, ReadOnly: true},
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: awsConfigVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: agent.AWSConfigMapName()},
+					},
+				},
+			},
+			{
+				Name: tokenVolume,
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience:          tokenAudience,
+								ExpirationSeconds: ptr(tokenExpirationSeconds),
+								Path:              "token",
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+}
+
+// env points the AWS SDK at the rendered config and tells the agent which agent and thread it
+// is. The agent's own variables come last so they cannot overwrite these.
+func (r *Reconciler) env(agent *agentsv1.Agent, thread agentsv1.AgentThread) []corev1.EnvVar {
+	env := []corev1.EnvVar{
+		{Name: "AWS_CONFIG_FILE", Value: awsConfigFilePath},
+		{Name: "AWS_PROFILE", Value: awsconfigclient.AgentScopedProfile},
+		{Name: "AWS_REGION", Value: r.Region},
+		{Name: "AGENT_NAME", Value: agent.Name},
+		{Name: "AGENT_THREAD", Value: thread.Name},
+		{Name: "AGENT_OWNER_EMAIL", Value: agent.Spec.OwnerEmail},
+	}
+
+	reserved := make(map[string]bool, len(env))
+	for _, e := range env {
+		reserved[e.Name] = true
+	}
+	for _, e := range agent.Spec.Runtime.Env {
+		if reserved[e.Name] {
+			continue
+		}
+		env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})
+	}
+	return env
+}
+
+// ensureWorkspaceSize grows a thread's existing workspace to the requested size. A provisioned
+// volume cannot shrink, so a smaller request is ignored rather than failing the thread. The
+// storage class allows expansion, but EBS limits a volume to one modification every six hours,
+// so a rejected patch is reported rather than retried into a wedge.
+func (r *Reconciler) ensureWorkspaceSize(ctx context.Context, agent *agentsv1.Agent, thread agentsv1.AgentThread) error {
+	desired, err := r.storageSize(agent)
+	if err != nil {
+		return err
+	}
+
+	claim := &corev1.PersistentVolumeClaim{}
+	key := types.NamespacedName{Namespace: r.Namespace, Name: agent.ThreadWorkspaceClaimName(thread.Name)}
+	err = r.Get(ctx, key, claim)
+	if apierrors.IsNotFound(err) {
+		// The StatefulSet has not created it yet; the claim template carries the size.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("getting workspace %s: %w", key.Name, err)
+	}
+
+	current := claim.Spec.Resources.Requests[corev1.ResourceStorage]
+	if desired.Cmp(current) <= 0 {
+		return nil
+	}
+
+	patched := claim.DeepCopy()
+	patched.Spec.Resources.Requests[corev1.ResourceStorage] = desired
+	err = r.Patch(ctx, patched, client.MergeFrom(claim))
+	if err != nil {
+		return fmt.Errorf("expanding workspace %s to %s: %w", key.Name, desired.String(), err)
+	}
+	return nil
+}
+
+// adoptWorkspace points the claim's ownership at the Agent. A StatefulSet does not delete the
+// claims it created, and its own reference would disappear when the set is recreated for a
+// resize, so the Agent owns the claim directly. Deleting the agent then releases the EBS
+// volume through the storage class's Delete reclaim policy.
+func (r *Reconciler) adoptWorkspace(ctx context.Context, agent *agentsv1.Agent, thread agentsv1.AgentThread) error {
+	claim := &corev1.PersistentVolumeClaim{}
+	key := types.NamespacedName{Namespace: r.Namespace, Name: agent.ThreadWorkspaceClaimName(thread.Name)}
+	err := r.Get(ctx, key, claim)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("getting workspace %s: %w", key.Name, err)
+	}
+
+	// A non-controller reference, because the StatefulSet controller may claim the controller
+	// slot under a retention policy.
+	patched := claim.DeepCopy()
+	err = controllerutil.SetOwnerReference(agent, patched, r.Scheme)
+	if err != nil {
+		return fmt.Errorf("setting owner on workspace %s: %w", key.Name, err)
+	}
+	if len(patched.OwnerReferences) == len(claim.OwnerReferences) {
+		return nil
+	}
+
+	if patched.Labels == nil {
+		patched.Labels = map[string]string{}
+	}
+	for k, v := range threadLabels(agent, thread.Name) {
+		patched.Labels[k] = v
+	}
+
+	err = r.Patch(ctx, patched, client.MergeFrom(claim))
+	if err != nil {
+		return fmt.Errorf("adopting workspace %s: %w", key.Name, err)
+	}
+	return nil
+}
+
+// claimTemplatesDiffer reports whether the immutable part of the spec changed, which can only
+// be applied by recreating the set.
+func claimTemplatesDiffer(existing, desired *appsv1.StatefulSet) bool {
+	if len(existing.Spec.VolumeClaimTemplates) != len(desired.Spec.VolumeClaimTemplates) {
+		return true
+	}
+	for i := range desired.Spec.VolumeClaimTemplates {
+		want := desired.Spec.VolumeClaimTemplates[i].Spec
+		got := existing.Spec.VolumeClaimTemplates[i].Spec
+		if !storageRequestsEqual(got, want) {
+			return true
+		}
+		if ptrValue(got.StorageClassName) != ptrValue(want.StorageClassName) {
+			return true
+		}
+	}
+	return false
+}
+
+func storageRequestsEqual(a, b corev1.PersistentVolumeClaimSpec) bool {
+	left := a.Resources.Requests[corev1.ResourceStorage]
+	right := b.Resources.Requests[corev1.ResourceStorage]
+	return left.Cmp(right) == 0
+}
+
+// equalStatefulSets compares the parts of a set this reconciler owns, so a steady-state
+// resync does not write.
+func equalStatefulSets(existing, desired *appsv1.StatefulSet) bool {
+	return equality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
+		equality.Semantic.DeepEqual(existing.Spec.Replicas, desired.Spec.Replicas) &&
+		equality.Semantic.DeepEqual(existing.Spec.Template, desired.Spec.Template)
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func ptrValue[T any](v *T) T {
+	if v == nil {
+		var zero T
+		return zero
+	}
+	return *v
+}

--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -9,8 +9,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,11 +33,22 @@ const agentFinalizer = "agents.czi.team/finalizer"
 // An agent can carry many grants across many accounts, so they are reconciled in parallel.
 const defaultGrantConcurrency = 8
 
-// AgentReconciler reconciles Agent objects by dispatching their grants to providers.
+// ThreadReconciler runs an agent's threads in the cluster. It is separate from Provider
+// because a thread is per-agent rather than per-grant, and because it needs the provisioned
+// role ARNs the providers return.
+type ThreadReconciler interface {
+	Reconcile(ctx context.Context, agent *agentsv1.Agent) ([]agentsv1.ThreadStatus, error)
+}
+
+// AgentReconciler reconciles Agent objects by dispatching their grants to providers and
+// running their threads in the cluster.
 type AgentReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
 	Providers []Provider
+	// Threads runs the agent's threads. Nil leaves agents without any pods, which is how the
+	// operator behaves in an environment where the runtime is not enabled.
+	Threads ThreadReconciler
 	// MaxConcurrentGrants bounds parallel per-grant provisioning within one agent. Zero
 	// uses defaultGrantConcurrency.
 	MaxConcurrentGrants int
@@ -44,6 +57,8 @@ type AgentReconciler struct {
 // +kubebuilder:rbac:groups=agents.czi.team,resources=agents,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=agents.czi.team,resources=agents/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=agents.czi.team,resources=agents/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts;services;configmaps;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile drives one Agent toward its desired state.
 func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -66,15 +81,27 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	statuses, reconcileErr := r.reconcileGrants(ctx, &agent)
+	grantStatuses, reconcileErr := r.reconcileGrants(ctx, &agent)
 
-	err = r.writeStatus(ctx, &agent, statuses)
+	// Threads run after the grants, because the AWS config their pods mount is built from the
+	// role ARNs the grants provisioned.
+	threadStatuses, threadErr := r.reconcileThreads(ctx, &agent)
+
+	err = r.writeStatus(ctx, &agent, grantStatuses, threadStatuses)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// Returning the error requeues with the workqueue's exponential backoff.
-	return ctrl.Result{}, reconcileErr
+	return ctrl.Result{}, errors.Join(reconcileErr, threadErr)
+}
+
+// reconcileThreads runs the agent's threads, if the operator has a thread reconciler.
+func (r *AgentReconciler) reconcileThreads(ctx context.Context, agent *agentsv1.Agent) ([]agentsv1.ThreadStatus, error) {
+	if r.Threads == nil {
+		return nil, nil
+	}
+	return r.Threads.Reconcile(ctx, agent)
 }
 
 // reconcileGrants provisions every grant, in parallel up to the concurrency limit, and
@@ -153,19 +180,20 @@ func (r *AgentReconciler) reconcileDelete(ctx context.Context, agent *agentsv1.A
 	return ctrl.Result{}, nil
 }
 
-// writeStatus records per-grant results, the observed generation, and the aggregate Ready
-// condition on the status subresource.
-func (r *AgentReconciler) writeStatus(ctx context.Context, agent *agentsv1.Agent, statuses []agentsv1.GrantStatus) error {
+// writeStatus records per-grant and per-thread results, the observed generation, and the
+// aggregate Ready and RuntimeReady conditions on the status subresource.
+func (r *AgentReconciler) writeStatus(ctx context.Context, agent *agentsv1.Agent, grants []agentsv1.GrantStatus, threads []agentsv1.ThreadStatus) error {
 	// Compute the desired status on a copy so we can compare it to the current one and only
 	// write when it actually changed. Writing unconditionally every reconcile creates a
 	// status -> watch -> reconcile storm, which (with a lagging cache) shows up as a stream
 	// of optimistic-lock "object has been modified" conflicts.
 	desired := agent.Status.DeepCopy()
-	desired.Grants = statuses
+	desired.Grants = grants
+	desired.Threads = threads
 	desired.ObservedGeneration = agent.Generation
 
 	ready := true
-	for _, s := range statuses {
+	for _, s := range grants {
 		if s.State != agentsv1.GrantStateProvisioned {
 			ready = false
 			break
@@ -185,6 +213,7 @@ func (r *AgentReconciler) writeStatus(ctx context.Context, agent *agentsv1.Agent
 		condition.Message = "all grants provisioned"
 	}
 	meta.SetStatusCondition(&desired.Conditions, condition)
+	meta.SetStatusCondition(&desired.Conditions, runtimeCondition(agent, threads))
 
 	if equality.Semantic.DeepEqual(&agent.Status, desired) {
 		return nil
@@ -198,6 +227,40 @@ func (r *AgentReconciler) writeStatus(ctx context.Context, agent *agentsv1.Agent
 	return nil
 }
 
+// runtimeCondition summarizes the agent's threads. A suspended thread is deliberately idle, so
+// it does not hold the condition false. An agent that does not run in the cluster reports true
+// with nothing to run, which keeps the condition meaningful rather than permanently false.
+func runtimeCondition(agent *agentsv1.Agent, threads []agentsv1.ThreadStatus) metav1.Condition {
+	condition := metav1.Condition{
+		Type:               agentsv1.ConditionRuntimeReady,
+		ObservedGeneration: agent.Generation,
+		Status:             metav1.ConditionTrue,
+	}
+
+	if agent.Spec.Runtime == nil {
+		condition.Reason = "NoRuntime"
+		condition.Message = "agent does not run in the cluster"
+		return condition
+	}
+
+	for _, thread := range threads {
+		if thread.State == agentsv1.ThreadStateRunning || thread.State == agentsv1.ThreadStateSuspended {
+			continue
+		}
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = "ThreadsPending"
+		condition.Message = fmt.Sprintf("thread %s is %s", thread.Name, strings.ToLower(string(thread.State)))
+		if thread.Message != "" {
+			condition.Message += ": " + thread.Message
+		}
+		return condition
+	}
+
+	condition.Reason = "AllThreadsRunning"
+	condition.Message = fmt.Sprintf("all %d threads running", len(threads))
+	return condition
+}
+
 // providerFor returns the first registered provider that handles the grant, or nil.
 func (r *AgentReconciler) providerFor(grant agentsv1.Grant) Provider {
 	for _, p := range r.Providers {
@@ -208,9 +271,12 @@ func (r *AgentReconciler) providerFor(grant agentsv1.Grant) Provider {
 	return nil
 }
 
-// SetupWithManager registers the reconciler with the manager.
+// SetupWithManager registers the reconciler with the manager. It also watches the StatefulSets
+// it owns, so a thread's pod becoming ready is reflected in the agent's status without waiting
+// for a resync.
 func (r *AgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&agentsv1.Agent{}).
+		Owns(&appsv1.StatefulSet{}).
 		Complete(r)
 }

--- a/internal/controller/agent_controller_test.go
+++ b/internal/controller/agent_controller_test.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agentsv1 "github.com/chanzuckerberg/aws-oidc/api/v1"
+)
+
+func TestRuntimeConditionWithoutRuntime(t *testing.T) {
+	agent := &agentsv1.Agent{}
+
+	condition := runtimeCondition(agent, nil)
+	require.Equal(t, metav1.ConditionTrue, condition.Status)
+	require.Equal(t, "NoRuntime", condition.Reason)
+}
+
+// A suspended thread is deliberately idle, so it must not hold the condition false forever.
+func TestRuntimeConditionIgnoresSuspendedThreads(t *testing.T) {
+	agent := &agentsv1.Agent{}
+	agent.Spec.Runtime = &agentsv1.AgentRuntime{}
+
+	condition := runtimeCondition(agent, []agentsv1.ThreadStatus{
+		{Name: "main", State: agentsv1.ThreadStateRunning},
+		{Name: "review", State: agentsv1.ThreadStateSuspended},
+	})
+	require.Equal(t, metav1.ConditionTrue, condition.Status)
+	require.Equal(t, "AllThreadsRunning", condition.Reason)
+}
+
+func TestRuntimeConditionReportsFailingThread(t *testing.T) {
+	agent := &agentsv1.Agent{}
+	agent.Spec.Runtime = &agentsv1.AgentRuntime{}
+
+	condition := runtimeCondition(agent, []agentsv1.ThreadStatus{
+		{Name: "main", State: agentsv1.ThreadStateRunning},
+		{Name: "review", State: agentsv1.ThreadStateFailed, Message: "agent is limited to 2 threads"},
+	})
+	require.Equal(t, metav1.ConditionFalse, condition.Status)
+	require.Equal(t, "ThreadsPending", condition.Reason)
+	require.Contains(t, condition.Message, "thread review is failed")
+	require.Contains(t, condition.Message, "limited to 2 threads")
+}

--- a/pkg/aws_config_client/agent_config.go
+++ b/pkg/aws_config_client/agent_config.go
@@ -90,7 +90,7 @@ func (r *AgentConfigRenderer) render(agent server.AgentConfig) (*ini.File, error
 
 	for i := range agent.Profiles {
 		profile := agent.Profiles[i]
-		err := r.addProfile(out, "profile "+agentProfileName(profile), profile)
+		err := r.addProfile(out, "profile "+AgentProfileName(profile), profile)
 		if err != nil {
 			return nil, err
 		}
@@ -153,8 +153,9 @@ func (r *AgentConfigRenderer) prune(agents []server.AgentConfig) error {
 	return nil
 }
 
-// agentProfileName is "<account>-<role>", sanitized the same way human account profile names
-// are. The agent name is not included because it is already the directory.
-func agentProfileName(profile server.AWSProfile) string {
+// AgentProfileName is "<account>-<role>", sanitized the same way human account profile names
+// are. The agent name is not included because it is already the directory. The operator uses
+// it too, so an agent's profiles are named the same whether it runs on a laptop or in a pod.
+func AgentProfileName(profile server.AWSProfile) string {
 	return sanitizeProfileName(fmt.Sprintf("%s-%s", profile.AWSAccount.GetAliasOrName(), profile.RoleName))
 }


### PR DESCRIPTION
## Overview

This is the PR that actually makes an agent run. Each thread in `spec.threads` becomes a pod in the cluster with a persistent workspace and working AWS credentials for every role the agent has been granted.

## Solution

A new `internal/agentpod` package owns the Kubernetes objects. Per agent it creates a headless service and a config map. Per thread it creates a service account and a StatefulSet whose volume claim template provisions an encrypted EBS volume for the workspace.

A thread is a StatefulSet of one rather than a Deployment or a bare pod. The workspace is the point of a thread, and the StatefulSet is what binds a stable name to a stable volume and brings both back after a node dies.

Credentials come from the config map, which holds a rendered AWS config with one profile per grant, each pointing at the projected service account token on disk. This is the same shape the CLI writes for a human, so an agent picks a role by profile name and any AWS SDK resolves it with no in-pod secret and no credential to rotate. The session name is the agent's name, so CloudTrail reads as the agent rather than an opaque identifier.

Pods get the least the platform allows. The default token mount is off since the agent has no reason to talk to the API server, privilege escalation is off, and the seccomp profile is the runtime default. The only token in the pod is the one projected for STS.

Two things need care in the lifecycle:

- Resizing storage means replacing the StatefulSet, because volume claim templates are immutable. The operator deletes it with orphaned pods, patches the existing claim, and recreates it, so the workspace and the running process survive. Volumes cannot shrink, so a smaller request is rejected rather than acted on.
- Removing a thread from the spec has to delete its objects explicitly. Owner references clean up when the agent is deleted, but not when a thread disappears from a list, so the operator prunes by label. Turning the runtime off removes the shared service and config map the same way.

Claims are adopted with the agent as a non-controller owner so a deleted agent does not leave volumes behind.

The manager's cache is scoped to the operator's namespace for these object types. The operator holds a namespaced role for them, and a cluster-wide informer would fail to start against it.

## Impact

Agents with a runtime start consuming cluster capacity and EBS volumes. Everything is gated on the operator being given a cluster OIDC provider and on the agent having `spec.runtime`, so this is inert until #1240 turns it on in rdev. A per-agent thread cap bounds how much any one agent can ask for.

## References

- Stacked on #1237.

The full stack, merge bottom-up:

1. #1236 the CRD schema and the design doc
2. #1237 the IAM trust policy
3. #1238 the operator running threads as pods
4. #1239 the portal
5. #1240 enabling it in rdev
6. chanzuckerberg/shared-infra#11978 the AWS identity provider and provisioner permission, which applies before #1237 merges
