### PR TITLE
feat(portal): size an agent's threads and add, suspend, and remove them

### DIFF
--- a/cmd/serve-portal.go
+++ b/cmd/serve-portal.go
@@ -13,6 +13,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	flagAgentRuntime    = "agent-runtime"
+	flagAgentMaxCPU     = "agent-max-cpu"
+	flagAgentMaxMemory  = "agent-max-memory"
+	flagAgentMaxStorage = "agent-max-storage"
+)
+
 var portalPort int
 
 func init() {
@@ -20,6 +27,11 @@ func init() {
 	servePortalCmd.Flags().IntVar(&portalPort, "web-server-port", 8080, "Port to host the portal on")
 	servePortalCmd.Flags().String(flagConfigMapName, "rolemap", "Name of the ConfigMap to read the rolemap from")
 	servePortalCmd.Flags().String(flagConfigMapKey, "rolemap.yaml", "Key within the ConfigMap that holds the rolemap YAML")
+	servePortalCmd.Flags().Bool(flagAgentRuntime, false, "Offer running an agent's threads as pods in the cluster; set this only where the operator is configured to run them")
+	servePortalCmd.Flags().String(flagAgentMaxCPU, "4", "Most CPU an agent thread may request")
+	servePortalCmd.Flags().String(flagAgentMaxMemory, "16Gi", "Most memory an agent thread may request")
+	servePortalCmd.Flags().String(flagAgentMaxStorage, "200Gi", "Largest workspace an agent thread may request")
+	servePortalCmd.Flags().Int(flagMaxThreadsPerAgent, 5, "Maximum threads one agent may run")
 }
 
 var servePortalCmd = &cobra.Command{
@@ -49,6 +61,14 @@ func servePortalRun(cmd *cobra.Command, args []string) error {
 	rolemapKey, err := cmd.Flags().GetString(flagConfigMapKey)
 	if err != nil {
 		return fmt.Errorf("missing configmap-key flag: %w", err)
+	}
+	agentRuntime, err := cmd.Flags().GetBool(flagAgentRuntime)
+	if err != nil {
+		return fmt.Errorf("missing agent-runtime flag: %w", err)
+	}
+	limits, err := agentLimits(cmd)
+	if err != nil {
+		return err
 	}
 
 	restConfig, namespace, err := configmap.NewInClusterConfig()
@@ -84,6 +104,8 @@ func servePortalRun(cmd *cobra.Command, args []string) error {
 		Store:            store,
 		Identity:         identity,
 		BasePath:         os.Getenv("PORTAL_BASE_PATH"),
+		AgentRuntime:     agentRuntime,
+		Limits:           limits,
 	})
 	if err != nil {
 		return fmt.Errorf("creating portal server: %w", err)
@@ -91,4 +113,31 @@ func servePortalRun(cmd *cobra.Command, args []string) error {
 
 	addr := fmt.Sprintf(":%d", portalPort)
 	return http.ListenAndServe(addr, srv.Handler())
+}
+
+// agentLimits reads the ceilings an agent owner is held to when sizing their threads.
+func agentLimits(cmd *cobra.Command) (portal.AgentLimits, error) {
+	maxCPU, err := cmd.Flags().GetString(flagAgentMaxCPU)
+	if err != nil {
+		return portal.AgentLimits{}, fmt.Errorf("missing agent-max-cpu flag: %w", err)
+	}
+	maxMemory, err := cmd.Flags().GetString(flagAgentMaxMemory)
+	if err != nil {
+		return portal.AgentLimits{}, fmt.Errorf("missing agent-max-memory flag: %w", err)
+	}
+	maxStorage, err := cmd.Flags().GetString(flagAgentMaxStorage)
+	if err != nil {
+		return portal.AgentLimits{}, fmt.Errorf("missing agent-max-storage flag: %w", err)
+	}
+	maxThreads, err := cmd.Flags().GetInt(flagMaxThreadsPerAgent)
+	if err != nil {
+		return portal.AgentLimits{}, fmt.Errorf("missing max-threads-per-agent flag: %w", err)
+	}
+
+	return portal.AgentLimits{
+		MaxCPU:     maxCPU,
+		MaxMemory:  maxMemory,
+		MaxStorage: maxStorage,
+		MaxThreads: maxThreads,
+	}, nil
 }

--- a/internal/portal/runtime.go
+++ b/internal/portal/runtime.go
@@ -1,0 +1,290 @@
+package portal
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	agentsv1 "github.com/chanzuckerberg/aws-oidc/api/v1"
+)
+
+// threadNameRe matches the CRD's thread name pattern, so the portal rejects a bad name with a
+// message instead of surfacing an API server validation error.
+var threadNameRe = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+const (
+	// firstThreadName is the thread an agent gets when its owner turns on the runtime without
+	// naming one, so enabling the runtime is a single click.
+	firstThreadName = "main"
+
+	defaultCPU     = "500m"
+	defaultMemory  = "1Gi"
+	defaultStorage = "20Gi"
+
+	threadNameMaxLength = 24
+)
+
+// AgentLimits caps what an owner may ask for when running an agent in the cluster. The portal
+// is the only place a person sets these, so this is where the ceiling belongs.
+type AgentLimits struct {
+	MaxCPU     string
+	MaxMemory  string
+	MaxStorage string
+	MaxThreads int
+}
+
+// defaults fills the unset caps and is where the numbers live.
+func (l AgentLimits) defaults() AgentLimits {
+	if l.MaxCPU == "" {
+		l.MaxCPU = "4"
+	}
+	if l.MaxMemory == "" {
+		l.MaxMemory = "16Gi"
+	}
+	if l.MaxStorage == "" {
+		l.MaxStorage = "200Gi"
+	}
+	if l.MaxThreads <= 0 {
+		l.MaxThreads = 5
+	}
+	return l
+}
+
+// runtimeForm is the runtime section of the agent form, both what is rendered and what a
+// submission is read back into so a rejected form comes back with the values the person typed.
+type runtimeForm struct {
+	Enabled bool
+	CPU     string
+	Memory  string
+	Storage string
+	Threads []threadForm
+	// NewThread is the name typed into the add-a-thread box, kept so a rejected form does not
+	// lose it.
+	NewThread string
+	Limits    AgentLimits
+}
+
+// threadForm is one row of the threads table, carrying the operator's report of the thread so
+// the owner sees whether it is actually running.
+type threadForm struct {
+	Name      string
+	Suspended bool
+	State     string
+	Message   string
+}
+
+// runtimeFromAgent builds the form's runtime section from a stored agent. A nil agent, or one
+// that does not run in the cluster, yields the defaults with the runtime off.
+func runtimeFromAgent(agent *agentsv1.Agent, limits AgentLimits) runtimeForm {
+	form := runtimeForm{
+		CPU:     defaultCPU,
+		Memory:  defaultMemory,
+		Storage: defaultStorage,
+		Limits:  limits,
+	}
+	if agent == nil || agent.Spec.Runtime == nil {
+		return form
+	}
+	runtime := agent.Spec.Runtime
+
+	form.Enabled = true
+	if cpu := runtime.Resources.Requests.Cpu(); !cpu.IsZero() {
+		form.CPU = cpu.String()
+	}
+	if memory := runtime.Resources.Requests.Memory(); !memory.IsZero() {
+		form.Memory = memory.String()
+	}
+	if runtime.Storage != nil && runtime.Storage.Size != "" {
+		form.Storage = runtime.Storage.Size
+	}
+
+	states := make(map[string]agentsv1.ThreadStatus, len(agent.Status.Threads))
+	for _, status := range agent.Status.Threads {
+		states[status.Name] = status
+	}
+	for _, thread := range agent.Spec.Threads {
+		status := states[thread.Name]
+		form.Threads = append(form.Threads, threadForm{
+			Name:      thread.Name,
+			Suspended: thread.Suspended,
+			State:     string(status.State),
+			Message:   status.Message,
+		})
+	}
+	return form
+}
+
+// runtimeFromForm reads the runtime section back out of a submission, for re-rendering a form
+// that failed validation.
+func runtimeFromForm(r *http.Request, limits AgentLimits) runtimeForm {
+	form := runtimeForm{
+		Enabled:   r.FormValue("runtime") != "",
+		CPU:       r.FormValue("cpu"),
+		Memory:    r.FormValue("memory"),
+		Storage:   r.FormValue("storage"),
+		NewThread: r.FormValue("new-thread"),
+		Limits:    limits,
+	}
+
+	suspended := selection(r.Form["suspended"])
+	removed := selection(r.Form["remove-thread"])
+	for _, name := range r.Form["thread"] {
+		if removed[name] {
+			continue
+		}
+		form.Threads = append(form.Threads, threadForm{Name: name, Suspended: suspended[name]})
+	}
+	return form
+}
+
+// parseRuntime turns a submission into the agent's desired runtime and threads. It returns nil
+// when the owner has not turned the runtime on, which is what tells the operator the agent has
+// no pods.
+//
+// Sizing is applied as both requests and limits, so a thread gets the CPU and memory it asked
+// for and cannot burst past it. That makes an agent's cost predictable, which matters when the
+// people creating them are not the people paying for them.
+func parseRuntime(r *http.Request, current *agentsv1.Agent, limits AgentLimits) (*agentsv1.AgentRuntime, []agentsv1.AgentThread, error) {
+	if r.FormValue("runtime") == "" {
+		return nil, nil, nil
+	}
+	limits = limits.defaults()
+
+	cpu, err := parseQuantity(r, "cpu", "CPU", defaultCPU, limits.MaxCPU)
+	if err != nil {
+		return nil, nil, err
+	}
+	memory, err := parseQuantity(r, "memory", "Memory", defaultMemory, limits.MaxMemory)
+	if err != nil {
+		return nil, nil, err
+	}
+	storage, err := parseQuantity(r, "storage", "Storage", defaultStorage, limits.MaxStorage)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// A provisioned volume cannot shrink, so a smaller request would be silently ignored.
+	// Refusing it says so instead of leaving the form disagreeing with reality.
+	err = rejectShrink(current, storage)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	threads, err := parseThreads(r, limits.MaxThreads)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sizing := corev1.ResourceList{corev1.ResourceCPU: cpu, corev1.ResourceMemory: memory}
+	runtime := &agentsv1.AgentRuntime{
+		Resources: corev1.ResourceRequirements{Requests: sizing, Limits: sizing.DeepCopy()},
+		Storage:   &agentsv1.AgentStorage{Size: storage.String()},
+	}
+	return runtime, threads, nil
+}
+
+// parseThreads reads the threads table: the rows that came back, minus the ones marked for
+// removal, plus a newly named one.
+func parseThreads(r *http.Request, maxThreads int) ([]agentsv1.AgentThread, error) {
+	suspended := selection(r.Form["suspended"])
+	removed := selection(r.Form["remove-thread"])
+
+	threads := make([]agentsv1.AgentThread, 0, len(r.Form["thread"])+1)
+	seen := map[string]bool{}
+
+	add := func(name string) error {
+		if seen[name] {
+			return fmt.Errorf("there is already a thread named %q", name)
+		}
+		seen[name] = true
+		threads = append(threads, agentsv1.AgentThread{Name: name, Suspended: suspended[name]})
+		return nil
+	}
+
+	for _, name := range r.Form["thread"] {
+		if removed[name] {
+			continue
+		}
+		err := add(name)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	newThread := strings.ToLower(strings.TrimSpace(r.FormValue("new-thread")))
+	if newThread != "" {
+		if len(newThread) > threadNameMaxLength {
+			return nil, fmt.Errorf("thread names are limited to %d characters", threadNameMaxLength)
+		}
+		if !threadNameRe.MatchString(newThread) {
+			return nil, fmt.Errorf("thread name %q must use only lowercase letters, numbers, and dashes", newThread)
+		}
+		err := add(newThread)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Turning the runtime on with no threads means one thread, rather than an agent that runs
+	// nothing.
+	if len(threads) == 0 {
+		threads = append(threads, agentsv1.AgentThread{Name: firstThreadName})
+	}
+
+	if len(threads) > maxThreads {
+		return nil, fmt.Errorf("an agent is limited to %d threads", maxThreads)
+	}
+	return threads, nil
+}
+
+// parseQuantity reads one sizing field, falling back to the default when it is blank and
+// refusing anything above the cap.
+func parseQuantity(r *http.Request, field, label, fallback, limit string) (resource.Quantity, error) {
+	raw := strings.TrimSpace(r.FormValue(field))
+	if raw == "" {
+		raw = fallback
+	}
+
+	value, err := resource.ParseQuantity(raw)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("%s %q is not a valid quantity (for example %s)", label, raw, fallback)
+	}
+	if value.Sign() <= 0 {
+		return resource.Quantity{}, fmt.Errorf("%s must be greater than zero", label)
+	}
+
+	ceiling, err := resource.ParseQuantity(limit)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("parsing %s limit %q: %w", label, limit, err)
+	}
+	if value.Cmp(ceiling) > 0 {
+		return resource.Quantity{}, fmt.Errorf("%s is limited to %s", label, ceiling.String())
+	}
+	return value, nil
+}
+
+func rejectShrink(current *agentsv1.Agent, storage resource.Quantity) error {
+	if current == nil || current.Spec.Runtime == nil || current.Spec.Runtime.Storage == nil {
+		return nil
+	}
+	existing, err := resource.ParseQuantity(current.Spec.Runtime.Storage.Size)
+	if err != nil {
+		return nil
+	}
+	if storage.Cmp(existing) < 0 {
+		return fmt.Errorf("storage cannot be reduced below the current %s", existing.String())
+	}
+	return nil
+}
+
+func selection(values []string) map[string]bool {
+	set := make(map[string]bool, len(values))
+	for _, value := range values {
+		set[value] = true
+	}
+	return set
+}

--- a/internal/portal/runtime_test.go
+++ b/internal/portal/runtime_test.go
@@ -1,0 +1,211 @@
+package portal
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agentsv1 "github.com/chanzuckerberg/aws-oidc/api/v1"
+	"github.com/chanzuckerberg/aws-oidc/pkg/identity"
+)
+
+// form builds the parsed submission the handlers hand to parseRuntime.
+func form(t *testing.T, values url.Values) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/agents", strings.NewReader(values.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	require.NoError(t, r.ParseForm())
+	return r
+}
+
+func TestParseRuntimeDisabled(t *testing.T) {
+	runtime, threads, err := parseRuntime(form(t, url.Values{}), nil, AgentLimits{})
+	require.NoError(t, err)
+	require.Nil(t, runtime)
+	require.Nil(t, threads)
+}
+
+// Turning the runtime on without naming a thread gives the agent one, so enabling it is a
+// single click rather than two steps.
+func TestParseRuntimeGivesAFirstThread(t *testing.T) {
+	runtime, threads, err := parseRuntime(form(t, url.Values{"runtime": {"on"}}), nil, AgentLimits{})
+	require.NoError(t, err)
+	require.NotNil(t, runtime)
+	require.Len(t, threads, 1)
+	require.Equal(t, firstThreadName, threads[0].Name)
+
+	// Sizing lands on both requests and limits, so a thread cannot burst past what its owner
+	// asked for.
+	require.Equal(t, defaultCPU, runtime.Resources.Requests.Cpu().String())
+	require.Equal(t, defaultCPU, runtime.Resources.Limits.Cpu().String())
+	require.Equal(t, defaultStorage, runtime.Storage.Size)
+}
+
+func TestParseRuntimeReadsSizing(t *testing.T) {
+	runtime, _, err := parseRuntime(form(t, url.Values{
+		"runtime": {"on"},
+		"cpu":     {"2"},
+		"memory":  {"4Gi"},
+		"storage": {"50Gi"},
+	}), nil, AgentLimits{})
+	require.NoError(t, err)
+
+	require.Equal(t, "2", runtime.Resources.Requests.Cpu().String())
+	require.Equal(t, "4Gi", runtime.Resources.Requests.Memory().String())
+	require.Equal(t, "50Gi", runtime.Storage.Size)
+}
+
+func TestParseRuntimeRejectsOversizedRequests(t *testing.T) {
+	_, _, err := parseRuntime(form(t, url.Values{"runtime": {"on"}, "cpu": {"64"}}), nil, AgentLimits{})
+	require.ErrorContains(t, err, "CPU is limited to 4")
+
+	_, _, err = parseRuntime(form(t, url.Values{"runtime": {"on"}, "memory": {"512Gi"}}), nil, AgentLimits{})
+	require.ErrorContains(t, err, "Memory is limited to 16Gi")
+
+	_, _, err = parseRuntime(form(t, url.Values{"runtime": {"on"}, "cpu": {"a lot"}}), nil, AgentLimits{})
+	require.ErrorContains(t, err, "not a valid quantity")
+}
+
+// A provisioned volume cannot shrink, so a smaller request is refused rather than accepted and
+// then quietly ignored by the operator.
+func TestParseRuntimeRefusesToShrinkStorage(t *testing.T) {
+	current := &agentsv1.Agent{Spec: agentsv1.AgentSpec{
+		Runtime: &agentsv1.AgentRuntime{Storage: &agentsv1.AgentStorage{Size: "50Gi"}},
+	}}
+
+	_, _, err := parseRuntime(form(t, url.Values{"runtime": {"on"}, "storage": {"20Gi"}}), current, AgentLimits{})
+	require.ErrorContains(t, err, "cannot be reduced below the current 50Gi")
+
+	_, _, err = parseRuntime(form(t, url.Values{"runtime": {"on"}, "storage": {"100Gi"}}), current, AgentLimits{})
+	require.NoError(t, err)
+}
+
+func TestParseThreadsAddsSuspendsAndRemoves(t *testing.T) {
+	values := url.Values{
+		"runtime":       {"on"},
+		"thread":        {"main", "review", "stale"},
+		"suspended":     {"review"},
+		"remove-thread": {"stale"},
+		"new-thread":    {"Docs"},
+	}
+
+	_, threads, err := parseRuntime(form(t, values), nil, AgentLimits{})
+	require.NoError(t, err)
+
+	require.Equal(t, []agentsv1.AgentThread{
+		{Name: "main"},
+		{Name: "review", Suspended: true},
+		// A name typed with capitals is lowercased rather than rejected, since the CRD only
+		// accepts a DNS label.
+		{Name: "docs"},
+	}, threads)
+}
+
+func TestParseThreadsRejectsBadAndDuplicateNames(t *testing.T) {
+	_, _, err := parseRuntime(form(t, url.Values{
+		"runtime":    {"on"},
+		"new-thread": {"my_thread"},
+	}), nil, AgentLimits{})
+	require.ErrorContains(t, err, "lowercase letters, numbers, and dashes")
+
+	_, _, err = parseRuntime(form(t, url.Values{
+		"runtime":    {"on"},
+		"thread":     {"main"},
+		"new-thread": {"main"},
+	}), nil, AgentLimits{})
+	require.ErrorContains(t, err, "already a thread named")
+
+	_, _, err = parseRuntime(form(t, url.Values{
+		"runtime":    {"on"},
+		"new-thread": {strings.Repeat("a", 25)},
+	}), nil, AgentLimits{})
+	require.ErrorContains(t, err, "limited to 24 characters")
+}
+
+func TestParseThreadsEnforcesTheLimit(t *testing.T) {
+	_, _, err := parseRuntime(form(t, url.Values{
+		"runtime": {"on"},
+		"thread":  {"a", "b", "c"},
+	}), nil, AgentLimits{MaxThreads: 2})
+	require.ErrorContains(t, err, "limited to 2 threads")
+}
+
+// Removing the last thread means the agent runs nothing, which is expressed by suspending or
+// disabling the runtime, not by an empty thread list.
+func TestParseThreadsRemovingTheLastThreadKeepsOne(t *testing.T) {
+	_, threads, err := parseRuntime(form(t, url.Values{
+		"runtime":       {"on"},
+		"thread":        {"main"},
+		"remove-thread": {"main"},
+	}), nil, AgentLimits{})
+	require.NoError(t, err)
+	require.Len(t, threads, 1)
+	require.Equal(t, firstThreadName, threads[0].Name)
+}
+
+func TestRuntimeFromAgentShowsStoredSizingAndState(t *testing.T) {
+	agent := &agentsv1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "bot"}}
+	agent.Spec.Runtime = &agentsv1.AgentRuntime{Storage: &agentsv1.AgentStorage{Size: "50Gi"}}
+	agent.Spec.Threads = []agentsv1.AgentThread{{Name: "main"}, {Name: "review", Suspended: true}}
+	agent.Status.Threads = []agentsv1.ThreadStatus{
+		{Name: "main", State: agentsv1.ThreadStateRunning},
+		{Name: "review", State: agentsv1.ThreadStateSuspended},
+	}
+
+	form := runtimeFromAgent(agent, AgentLimits{}.defaults())
+	require.True(t, form.Enabled)
+	require.Equal(t, "50Gi", form.Storage)
+	// Sizing the agent never set falls back to the default rather than rendering blank.
+	require.Equal(t, defaultCPU, form.CPU)
+	require.Equal(t, []threadForm{
+		{Name: "main", State: "Running"},
+		{Name: "review", Suspended: true, State: "Suspended"},
+	}, form.Threads)
+}
+
+// The runtime section is only rendered where the operator can actually run threads.
+func TestFormHidesRuntimeWhenNotOffered(t *testing.T) {
+	withRuntime, err := NewServer(Config{AgentRuntime: true})
+	require.NoError(t, err)
+	withoutRuntime, err := NewServer(Config{})
+	require.NoError(t, err)
+
+	data := pageData{
+		Title:        "Edit",
+		User:         &identity.User{Sub: "s"},
+		Agent:        &agentsv1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "bot"}},
+		Entitlements: &Entitlements{},
+		Runtime:      runtimeFromAgent(nil, AgentLimits{}.defaults()),
+		Action:       "/agents/bot",
+	}
+
+	shown := httptest.NewRecorder()
+	withRuntime.render(shown, "form", data)
+	require.Contains(t, shown.Body.String(), "Run this agent as pods")
+	require.Contains(t, shown.Body.String(), `name="storage"`)
+
+	hidden := httptest.NewRecorder()
+	withoutRuntime.render(hidden, "form", data)
+	require.NotContains(t, hidden.Body.String(), "Run this agent as pods")
+}
+
+// A portal that does not offer the runtime must not clear the runtime of an agent that has one.
+func TestParseAgentRuntimeLeavesStoredRuntimeAloneWhenNotOffered(t *testing.T) {
+	s, err := NewServer(Config{})
+	require.NoError(t, err)
+
+	current := &agentsv1.Agent{Spec: agentsv1.AgentSpec{
+		Runtime: &agentsv1.AgentRuntime{Storage: &agentsv1.AgentStorage{Size: "50Gi"}},
+		Threads: []agentsv1.AgentThread{{Name: "main"}},
+	}}
+
+	runtime, threads, err := s.parseAgentRuntime(form(t, url.Values{}), current)
+	require.NoError(t, err)
+	require.Equal(t, current.Spec.Runtime, runtime)
+	require.Equal(t, current.Spec.Threads, threads)
+}

--- a/internal/portal/server.go
+++ b/internal/portal/server.go
@@ -40,6 +40,11 @@ type Config struct {
 	Store            agentstore.AgentStore
 	Identity         *IdentityResolver
 	BasePath         string
+	// AgentRuntime offers the option of running an agent's threads as pods. It is off unless
+	// the operator can actually run them, so the form does not promise what it cannot deliver.
+	AgentRuntime bool
+	// Limits caps the sizing an owner may ask for. Unset fields fall back to defaults.
+	Limits AgentLimits
 }
 
 // Server is the agent-registry portal.
@@ -55,6 +60,7 @@ func NewServer(cfg Config) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing templates: %w", err)
 	}
+	cfg.Limits = cfg.Limits.defaults()
 	return &Server{cfg: cfg, tmpl: tmpl, basePath: strings.TrimRight(cfg.BasePath, "/")}, nil
 }
 
@@ -100,6 +106,10 @@ type pageData struct {
 	Checked      map[string]bool
 	Action       string
 	Error        string
+	// RuntimeOffered mirrors Config.AgentRuntime, so the form hides the section entirely in an
+	// environment where agents do not run in the cluster.
+	RuntimeOffered bool
+	Runtime        runtimeForm
 }
 
 func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
@@ -142,6 +152,7 @@ func (s *Server) handleNew(w http.ResponseWriter, r *http.Request) {
 		Entitlements: ent,
 		Checked:      map[string]bool{},
 		Action:       "/agents",
+		Runtime:      runtimeFromAgent(nil, s.cfg.Limits),
 	})
 }
 
@@ -169,6 +180,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 		s.render(w, "form", pageData{
 			Title: "Register agent", User: user, Entitlements: ent,
 			Checked: checkedFromForm(r), Action: "/agents", Error: msg,
+			Runtime: runtimeFromForm(r, s.cfg.Limits),
 		})
 	}
 
@@ -193,6 +205,12 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	runtime, threads, err := s.parseAgentRuntime(r, nil)
+	if err != nil {
+		renderErr(err.Error())
+		return
+	}
+
 	agent := &agentsv1.Agent{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: agentsv1.AgentSpec{
@@ -200,6 +218,8 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 			Owner:       user.Sub,
 			OwnerEmail:  user.Email,
 			Grants:      grants,
+			Runtime:     runtime,
+			Threads:     threads,
 		},
 	}
 	err = s.cfg.Store.Upsert(ctx, agent)
@@ -237,6 +257,7 @@ func (s *Server) handleView(w http.ResponseWriter, r *http.Request) {
 		Entitlements: ent,
 		Checked:      checkedFromAgent(agent),
 		Action:       "/agents/" + agent.Name,
+		Runtime:      runtimeFromAgent(agent, s.cfg.Limits),
 	})
 }
 
@@ -264,16 +285,29 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	grants, err := parseGrants(r, ent)
-	if err != nil {
+	renderErr := func(msg string) {
 		s.render(w, "form", pageData{
 			Title: "Edit " + agent.Name, User: user, Agent: agent, Entitlements: ent,
-			Checked: checkedFromForm(r), Action: "/agents/" + agent.Name, Error: err.Error(),
+			Checked: checkedFromForm(r), Action: "/agents/" + agent.Name, Error: msg,
+			Runtime: runtimeFromForm(r, s.cfg.Limits),
 		})
+	}
+
+	grants, err := parseGrants(r, ent)
+	if err != nil {
+		renderErr(err.Error())
+		return
+	}
+
+	runtime, threads, err := s.parseAgentRuntime(r, agent)
+	if err != nil {
+		renderErr(err.Error())
 		return
 	}
 
 	agent.Spec.Grants = grants
+	agent.Spec.Runtime = runtime
+	agent.Spec.Threads = threads
 	err = s.cfg.Store.Upsert(ctx, agent)
 	if err != nil {
 		s.fail(w, "updating agent", err)
@@ -339,8 +373,22 @@ func (s *Server) user(w http.ResponseWriter, r *http.Request) (*identity.User, b
 	return user, true
 }
 
+// parseAgentRuntime reads the runtime section of a submission, or leaves the agent's runtime
+// alone in an environment where the portal does not offer it. Without that guard a form posted
+// against a portal with the runtime disabled would silently clear an existing runtime.
+func (s *Server) parseAgentRuntime(r *http.Request, current *agentsv1.Agent) (*agentsv1.AgentRuntime, []agentsv1.AgentThread, error) {
+	if !s.cfg.AgentRuntime {
+		if current == nil {
+			return nil, nil, nil
+		}
+		return current.Spec.Runtime, current.Spec.Threads, nil
+	}
+	return parseRuntime(r, current, s.cfg.Limits)
+}
+
 func (s *Server) render(w http.ResponseWriter, name string, data pageData) {
 	data.BasePath = s.basePath
+	data.RuntimeOffered = s.cfg.AgentRuntime
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	err := s.tmpl.ExecuteTemplate(w, name, data)
 	if err != nil {

--- a/internal/portal/templates/form.html
+++ b/internal/portal/templates/form.html
@@ -25,6 +25,53 @@
     <p class="muted">You have no AWS access to grant.</p>
     {{end}}
 
+    {{if .RuntimeOffered}}
+    {{with .Runtime}}
+    <fieldset>
+      <legend>Run in the cluster</legend>
+      <label class="grant">
+        <input type="checkbox" name="runtime" value="on" {{if .Enabled}}checked{{end}}>
+        Run this agent as pods in the cluster
+      </label>
+      <p class="muted">
+        Each thread gets its own pod and its own persistent workspace, and assumes the access
+        granted above. Sizing applies to every thread.
+      </p>
+
+      <p class="sizing">
+        <label>CPU <input name="cpu" value="{{.CPU}}" placeholder="500m" size="8"></label>
+        <label>Memory <input name="memory" value="{{.Memory}}" placeholder="1Gi" size="8"></label>
+        <label>Storage <input name="storage" value="{{.Storage}}" placeholder="20Gi" size="8"></label>
+        <span class="muted">up to {{.Limits.MaxCPU}} CPU, {{.Limits.MaxMemory}} memory, {{.Limits.MaxStorage}} storage</span>
+      </p>
+      <p class="muted">Storage can be increased but not reduced, because a provisioned volume cannot shrink.</p>
+
+      {{if .Threads}}
+      <table>
+        <tr><th>Thread</th><th>State</th><th>Suspend</th><th>Remove</th></tr>
+        {{range .Threads}}
+        <tr>
+          <td>{{.Name}}<input type="hidden" name="thread" value="{{.Name}}"></td>
+          <td>{{if .State}}{{.State}}{{else}}<span class="muted">—</span>{{end}}
+            {{if .Message}}<span class="muted">{{.Message}}</span>{{end}}</td>
+          <td><input type="checkbox" name="suspended" value="{{.Name}}" {{if .Suspended}}checked{{end}}></td>
+          <td><input type="checkbox" name="remove-thread" value="{{.Name}}"></td>
+        </tr>
+        {{end}}
+      </table>
+      <p class="muted">Suspending a thread stops its pod and keeps its workspace. Removing it deletes both.</p>
+      {{end}}
+
+      <p>
+        <label>Add a thread
+          <input name="new-thread" value="{{.NewThread}}" pattern="[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?" maxlength="24" placeholder="review">
+        </label>
+        <span class="muted">up to {{.Limits.MaxThreads}} threads</span>
+      </p>
+    </fieldset>
+    {{end}}
+    {{end}}
+
     <p>
       <button class="btn primary" type="submit">Save</button>
       <a class="btn" href="{{.BasePath}}/">Cancel</a>

--- a/internal/portal/templates/layout.html
+++ b/internal/portal/templates/layout.html
@@ -17,6 +17,7 @@
     fieldset { margin: .6rem 0; border: 1px solid #ddd; border-radius: 5px; }
     legend { font-weight: 600; }
     label.grant { display: block; padding: .15rem 0; }
+    p.sizing { display: flex; align-items: center; flex-wrap: wrap; gap: .9rem; }
     .err { color: #b00020; font-weight: 600; }
     .danger { color: #b00020; }
     form.inline { display: inline; }

--- a/internal/portal/templates/list.html
+++ b/internal/portal/templates/list.html
@@ -7,6 +7,7 @@
       <th>Name</th>
       {{if .User.Admin}}<th>Owner</th>{{end}}
       <th>Granted access (account / role)</th>
+      {{if .RuntimeOffered}}<th>Threads</th>{{end}}
       <th></th>
     </tr>
     {{range .Agents}}
@@ -16,6 +17,11 @@
       <td>
         {{range .Spec.Grants}}{{with .AWS}}{{.AccountAlias}} / {{.RoleName}}<br>{{end}}{{else}}<span class="muted">none</span>{{end}}
       </td>
+      {{if $.RuntimeOffered}}
+      <td>
+        {{range .Status.Threads}}{{.Name}} <span class="muted">{{.State}}</span><br>{{else}}<span class="muted">not running</span>{{end}}
+      </td>
+      {{end}}
       <td>
         <a class="btn" href="{{$.BasePath}}/agents/{{.Name}}">edit</a>
         <form class="inline" method="post" action="{{$.BasePath}}/agents/{{.Name}}/delete" onsubmit="return confirm('Delete {{.Name}}?');">


### PR DESCRIPTION
## Overview

Threads and sizing are only reachable by editing the custom resource directly, which the people who own agents do not do. This PR puts both in the portal, so an owner registers an agent, gives it CPU, memory, and storage, and adds threads without touching Kubernetes.

## Solution

The registration and edit form grows a runtime section behind a checkbox. Unchecked means the agent has no compute and the form looks like it does today. Checked reveals CPU, memory, and storage, each showing the ceiling the portal is configured to allow, and a table of threads.

The whole section only renders when the portal is started with the runtime enabled. An operator running without a cluster runtime should not be shown fields that would do nothing, and submissions in that state leave a stored runtime alone rather than clearing it, so enabling the feature is not destructive.

Threads are managed as a list. An owner names a new one, and existing rows offer suspend and remove. Suspend scales a thread to zero and keeps its workspace, which is the common case of pausing work. Remove is what discards the volume, so the two are separate actions.

Validation happens before anything is written. Requests are parsed as quantities and checked against the configured maximums, thread names must be valid Kubernetes names and unique within the agent, the thread count is capped, and a storage request smaller than the current one is refused with an explanation rather than silently ignored. On any error the form comes back with what was typed still in it.

The agent list shows each agent's threads and their states so an owner can see what is running without opening the agent.

## Impact

Owners can size and scale their own agents within limits the platform sets, instead of filing a request. Maximums and the thread cap are CLI flags, so an operator decides how much any one agent can ask for.

## References

- Stacked on #1238.

The full stack, merge bottom-up:

1. #1236 the CRD schema and the design doc
2. #1237 the IAM trust policy
3. #1238 the operator running threads as pods
4. #1239 the portal
5. #1240 enabling it in rdev
6. chanzuckerberg/shared-infra#11978 the AWS identity provider and provisioner permission, which applies before #1237 merges
