### PR TITLE
chore(infra): enable the agent runtime in rdev

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -33,6 +33,13 @@ stack:
           memory: 500Mi
       args:
         - serve-portal
+        # Offer running agents as pods. The operator below is configured with the cluster's
+        # OIDC issuer, so a thread's pod can assume the agent's roles.
+        - --agent-runtime
+        - --agent-max-cpu=4
+        - --agent-max-memory=16Gi
+        - --agent-max-storage=200Gi
+        - --max-threads-per-agent=5
         - -v
       gateway:
         oidcProtected: true
@@ -105,6 +112,17 @@ stack:
         # Standard tags applied to every agent role, alongside the operator's own
         # managedBy/owner and per-agent tags.
         - --role-tags=project=agent-registry,env=rdev,service=aws-oidc
+        # dev-central's OIDC issuer. Setting it is what turns on running agents in the cluster:
+        # each agent role trusts this issuer for that agent's thread service accounts, so a
+        # thread's pod assumes the role with its projected token. The provider must also be
+        # registered in every account holding agent roles (shared-infra).
+        - --cluster-oidc-provider=oidc.eks.us-west-2.amazonaws.com/id/A72DBBC7C19B4B419EEA3497A3A4CC03
+        # Placeholder base image until the real agent image (with the CLI preinstalled) exists.
+        # It has no long-running entrypoint, so the default command keeps the pod up.
+        - --agent-default-image=docker.io/library/ubuntu:24.04
+        - --agent-storage-class=ebs-csi-encrypted-gp3
+        - --agent-default-storage-size=20Gi
+        - --max-threads-per-agent=5
         - -v
       # The operator serves no traffic; it only needs the health endpoint.
       ingress:


### PR DESCRIPTION
## Overview

This is the PR that turns the rest of the stack on, in rdev only. Everything below it is inert without configuration, so this is the single place the behavior actually starts.

## Solution

The operator is given dev-central's OIDC issuer, which is what makes it write the cluster statement into trust policies and start reconciling threads. It also gets the defaults a thread runs with when the agent does not specify them, including the base image, the command, the encrypted gp3 storage class, and a starting volume size.

The portal is given the runtime flag and the ceilings an owner can request within.

Both get the same per-agent thread cap so the portal refuses what the operator would.

The base image is a plain Ubuntu for now. Threads sleep rather than doing anything, which is enough to prove identity, credentials, and the workspace end to end. The real agent image replaces it later without any change here beyond the flag.

## Impact

Agents in rdev can run. Nothing in prod changes, since prod values are untouched.

Revert this PR alone to turn the feature off, which leaves the rest of the stack in place and dormant.

## References

- Stacked on #1239, the top of the stack.

The full stack, merge bottom-up:

1. #1236 the CRD schema and the design doc
2. #1237 the IAM trust policy
3. #1238 the operator running threads as pods
4. #1239 the portal
5. #1240 enabling it in rdev
6. chanzuckerberg/shared-infra#11978 the AWS identity provider and provisioner permission, which applies before #1237 merges
