### PR TITLE
perf(portal): cache Okta entitlements per user with stale-while-revalidate

### DIFF
--- a/internal/portal/cache.go
+++ b/internal/portal/cache.go
@@ -1,0 +1,105 @@
+package portal
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const defaultEntitlementsTTL = 5 * time.Minute
+
+type cachedEntry struct {
+	value      *Entitlements
+	fetchedAt  time.Time
+	refreshing bool
+}
+
+func (e *cachedEntry) stale(ttl time.Duration) bool {
+	return time.Since(e.fetchedAt) > ttl
+}
+
+// EntitlementsCache is a per-user stale-while-revalidate cache for Okta entitlements.
+// The first request for a user is synchronous (one Okta call). Subsequent requests return
+// the cached value immediately; a background refresh starts when the entry ages past the TTL.
+// Concurrent cold-start requests for the same user are collapsed by singleflight so Okta
+// never sees a burst of identical calls.
+type EntitlementsCache struct {
+	mu      sync.Mutex
+	entries map[string]*cachedEntry
+	ttl     time.Duration
+	group   singleflight.Group
+	fetch   func(ctx context.Context, sub string) (*Entitlements, error)
+}
+
+func newEntitlementsCache(ttl time.Duration, fetch func(ctx context.Context, sub string) (*Entitlements, error)) *EntitlementsCache {
+	if ttl <= 0 {
+		ttl = defaultEntitlementsTTL
+	}
+	return &EntitlementsCache{
+		entries: make(map[string]*cachedEntry),
+		ttl:     ttl,
+		fetch:   fetch,
+	}
+}
+
+// Get returns entitlements for the given user. On a cache miss it fetches synchronously.
+// On a stale hit it returns the cached value immediately and refreshes in the background.
+func (c *EntitlementsCache) Get(ctx context.Context, sub string) (*Entitlements, error) {
+	c.mu.Lock()
+	entry := c.entries[sub]
+	c.mu.Unlock()
+
+	if entry != nil && !entry.stale(c.ttl) {
+		return entry.value, nil
+	}
+
+	if entry != nil {
+		c.tryRefresh(sub)
+		return entry.value, nil
+	}
+
+	v, err, _ := c.group.Do(sub, func() (interface{}, error) {
+		ent, err := c.fetch(ctx, sub)
+		if err != nil {
+			return nil, err
+		}
+		c.mu.Lock()
+		c.entries[sub] = &cachedEntry{value: ent, fetchedAt: time.Now()}
+		c.mu.Unlock()
+		return ent, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*Entitlements), nil
+}
+
+// tryRefresh starts a background goroutine to refresh the entry for sub. It is a no-op if a
+// refresh is already in flight for this user.
+func (c *EntitlementsCache) tryRefresh(sub string) {
+	c.mu.Lock()
+	entry := c.entries[sub]
+	if entry == nil || entry.refreshing {
+		c.mu.Unlock()
+		return
+	}
+	entry.refreshing = true
+	c.mu.Unlock()
+
+	go func() {
+		ent, err := c.fetch(context.Background(), sub)
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if err != nil {
+			slog.Warn("background entitlements refresh failed", "sub", sub, "error", err)
+			if c.entries[sub] != nil {
+				c.entries[sub].refreshing = false
+			}
+			return
+		}
+		c.entries[sub] = &cachedEntry{value: ent, fetchedAt: time.Now()}
+	}()
+}

--- a/internal/portal/server.go
+++ b/internal/portal/server.go
@@ -53,6 +53,7 @@ type Server struct {
 	cfg      Config
 	tmpl     *template.Template
 	basePath string
+	entCache *EntitlementsCache
 }
 
 // NewServer parses templates and returns a portal server.
@@ -62,7 +63,9 @@ func NewServer(cfg Config) (*Server, error) {
 		return nil, fmt.Errorf("parsing templates: %w", err)
 	}
 	cfg.Limits = cfg.Limits.defaults()
-	return &Server{cfg: cfg, tmpl: tmpl, basePath: strings.TrimRight(cfg.BasePath, "/")}, nil
+	s := &Server{cfg: cfg, tmpl: tmpl, basePath: strings.TrimRight(cfg.BasePath, "/")}
+	s.entCache = newEntitlementsCache(0, s.fetchEntitlements)
+	return s, nil
 }
 
 // Handler returns the HTTP handler for the portal.
@@ -398,6 +401,10 @@ func (s *Server) ownedAgent(w http.ResponseWriter, r *http.Request, user *identi
 }
 
 func (s *Server) entitlements(ctx context.Context, sub string) (*Entitlements, error) {
+	return s.entCache.Get(ctx, sub)
+}
+
+func (s *Server) fetchEntitlements(ctx context.Context, sub string) (*Entitlements, error) {
 	mappings, err := s.cfg.MappingsProvider(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("reading rolemap: %w", err)


### PR DESCRIPTION
The agent edit form fetches every Okta app assigned to the owner on every page load. With many app assignments this dominates latency and makes the edit form feel slow.

Every call to `handleView`, `handleNew`, `handleCreate`, and `handleUpdate` goes through `s.entitlements(ctx, sub)`, which paginates the Okta Applications API to build the list of accounts and roles the owner can grant. That call is unchanged in frequency and content between requests but paid in full every time.

The fix is a per-user stale-while-revalidate cache in `internal/portal/cache.go`:

- The first request for a user fetches synchronously as before, so cold starts are no slower.
- Subsequent requests return the cached value immediately, cutting the Okta round-trips to zero.
- When an entry ages past 5 minutes a background goroutine refreshes it so the next hit is instant. The page never blocks on a stale refresh.
- Concurrent cold-start requests for the same user are collapsed into one Okta call by `singleflight.Group`, preventing thundering-herd on restart.

The rolemap (ConfigMap) is still read fresh on every request since it is a cheap local Kubernetes API call and changes more frequently than Okta app assignments.

Stacked on #1222.