### PR TITLE
feat(agent): block agent commits and pushes to primary branches

### DIFF
--- a/.infra/prod/config/git-branch-guard.sh
+++ b/.infra/prod/config/git-branch-guard.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Claude Code. Reads the hook JSON on stdin and blocks any
+# Bash command that would commit to, or push directly to, a repository's primary
+# branch (main, master, or the remote's default). Agents must branch and open a
+# pull request. Exits 2 to block the tool call; 0 to allow it. Claude Code fires
+# PreToolUse hooks even in bypassPermissions mode.
+
+set -euo pipefail
+
+input=$(cat)
+
+tool_name=$(echo "${input}" | jq -r '.tool_name // empty')
+if [[ "${tool_name}" != "Bash" ]]; then
+    exit 0
+fi
+
+command=$(echo "${input}" | jq -r '.tool_input.command // empty')
+if [[ -z "${command}" ]]; then
+    exit 0
+fi
+
+if ! grep -qE '(^|[;&|`(]|[[:space:]])git([[:space:]]|$)' <<<"${command}"; then
+    exit 0
+fi
+
+# Match commit and push as the git subcommand, tolerating global options
+# (-C path, -c key=val, --flag[=val]) between "git" and the subcommand.
+git_global='([[:space:]]+(-C[[:space:]]+[^[:space:]]+|-c[[:space:]]+[^[:space:]]+|--[A-Za-z-]+(=[^[:space:]]+)?))*'
+is_commit=false
+is_push=false
+if grep -qE "(^|[;&|\`(]|[[:space:]])git${git_global}[[:space:]]+commit([[:space:]]|$)" <<<"${command}"; then
+    is_commit=true
+fi
+if grep -qE "(^|[;&|\`(]|[[:space:]])git${git_global}[[:space:]]+push([[:space:]]|$)" <<<"${command}"; then
+    is_push=true
+fi
+
+if [[ "${is_commit}" == "false" && "${is_push}" == "false" ]]; then
+    exit 0
+fi
+
+# Resolve the repository this command runs against: prefer an explicit
+# "git -C <path>", otherwise the tool's working directory.
+cwd=$(echo "${input}" | jq -r '.cwd // empty')
+repo_dir="${cwd:-$(pwd)}"
+if grep -qE '(^|[[:space:]])git[[:space:]]+-C[[:space:]]+[^[:space:]]+' <<<"${command}"; then
+    repo_dir=$(grep -oE '(^|[[:space:]])git[[:space:]]+-C[[:space:]]+[^[:space:]]+' <<<"${command}" | head -1 | awk '{print $NF}' || true)
+fi
+
+git_c=(git -C "${repo_dir}")
+
+protected_names="main master"
+default_branch=$("${git_c[@]}" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)
+if [[ -n "${default_branch}" ]]; then
+    protected_names="${protected_names} ${default_branch}"
+fi
+
+is_protected() {
+    local name="${1:-}" candidate
+    [[ -n "${name}" ]] || return 1
+    for candidate in ${protected_names}; do
+        [[ "${name}" == "${candidate}" ]] && return 0
+    done
+    return 1
+}
+
+current_branch=$("${git_c[@]}" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+
+deny() {
+    echo "git-branch-guard: $1" >&2
+    echo "git-branch-guard: agents must not put work on a primary branch directly." >&2
+    echo "git-branch-guard: branch first, then open a PR, e.g. 'git switch -c <branch>', push, and 'gh pr create'." >&2
+    exit 2
+}
+
+if [[ "${is_commit}" == "true" ]] && is_protected "${current_branch}"; then
+    deny "refusing to commit on primary branch '${current_branch}'"
+fi
+
+if [[ "${is_push}" == "true" ]]; then
+    push_segment=$(grep -oE "git${git_global}[[:space:]]+push[^;&|]*" <<<"${command}" | head -1 || true)
+    refspecs=${push_segment#*push}
+
+    ref_count=0
+    for tok in ${refspecs}; do
+        [[ "${tok}" == -* ]] && continue
+        ref_count=$((ref_count + 1))
+        dst=${tok##*:}
+        dst=${dst#+}
+        if [[ "${dst}" == "HEAD" ]]; then
+            dst="${current_branch}"
+        fi
+        if is_protected "${dst}"; then
+            deny "refusing to push to primary branch '${dst}'"
+        fi
+    done
+
+    # A bare push (no refspec, at most a remote) sends the current branch. Block
+    # it when that branch is primary.
+    if [[ ${ref_count} -le 1 ]] && is_protected "${current_branch}"; then
+        deny "refusing to push primary branch '${current_branch}'"
+    fi
+fi
+
+exit 0

--- a/.infra/prod/config/managed-settings.json
+++ b/.infra/prod/config/managed-settings.json
@@ -8,6 +8,10 @@
           {
             "type": "command",
             "command": "bash /etc/claude-code/ssh-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash /etc/claude-code/git-branch-guard.sh"
           }
         ]
       }

--- a/.infra/prod/templates/agent-managed-settings.yaml
+++ b/.infra/prod/templates/agent-managed-settings.yaml
@@ -8,3 +8,5 @@ data:
 {{ .Files.Get "config/managed-settings.json" | indent 4 }}
   ssh-guard.sh: |
 {{ .Files.Get "config/ssh-guard.sh" | indent 4 }}
+  git-branch-guard.sh: |
+{{ .Files.Get "config/git-branch-guard.sh" | indent 4 }}

--- a/.infra/rdev/config/git-branch-guard.sh
+++ b/.infra/rdev/config/git-branch-guard.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Claude Code. Reads the hook JSON on stdin and blocks any
+# Bash command that would commit to, or push directly to, a repository's primary
+# branch (main, master, or the remote's default). Agents must branch and open a
+# pull request. Exits 2 to block the tool call; 0 to allow it. Claude Code fires
+# PreToolUse hooks even in bypassPermissions mode.
+
+set -euo pipefail
+
+input=$(cat)
+
+tool_name=$(echo "${input}" | jq -r '.tool_name // empty')
+if [[ "${tool_name}" != "Bash" ]]; then
+    exit 0
+fi
+
+command=$(echo "${input}" | jq -r '.tool_input.command // empty')
+if [[ -z "${command}" ]]; then
+    exit 0
+fi
+
+if ! grep -qE '(^|[;&|`(]|[[:space:]])git([[:space:]]|$)' <<<"${command}"; then
+    exit 0
+fi
+
+# Match commit and push as the git subcommand, tolerating global options
+# (-C path, -c key=val, --flag[=val]) between "git" and the subcommand.
+git_global='([[:space:]]+(-C[[:space:]]+[^[:space:]]+|-c[[:space:]]+[^[:space:]]+|--[A-Za-z-]+(=[^[:space:]]+)?))*'
+is_commit=false
+is_push=false
+if grep -qE "(^|[;&|\`(]|[[:space:]])git${git_global}[[:space:]]+commit([[:space:]]|$)" <<<"${command}"; then
+    is_commit=true
+fi
+if grep -qE "(^|[;&|\`(]|[[:space:]])git${git_global}[[:space:]]+push([[:space:]]|$)" <<<"${command}"; then
+    is_push=true
+fi
+
+if [[ "${is_commit}" == "false" && "${is_push}" == "false" ]]; then
+    exit 0
+fi
+
+# Resolve the repository this command runs against: prefer an explicit
+# "git -C <path>", otherwise the tool's working directory.
+cwd=$(echo "${input}" | jq -r '.cwd // empty')
+repo_dir="${cwd:-$(pwd)}"
+if grep -qE '(^|[[:space:]])git[[:space:]]+-C[[:space:]]+[^[:space:]]+' <<<"${command}"; then
+    repo_dir=$(grep -oE '(^|[[:space:]])git[[:space:]]+-C[[:space:]]+[^[:space:]]+' <<<"${command}" | head -1 | awk '{print $NF}' || true)
+fi
+
+git_c=(git -C "${repo_dir}")
+
+protected_names="main master"
+default_branch=$("${git_c[@]}" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)
+if [[ -n "${default_branch}" ]]; then
+    protected_names="${protected_names} ${default_branch}"
+fi
+
+is_protected() {
+    local name="${1:-}" candidate
+    [[ -n "${name}" ]] || return 1
+    for candidate in ${protected_names}; do
+        [[ "${name}" == "${candidate}" ]] && return 0
+    done
+    return 1
+}
+
+current_branch=$("${git_c[@]}" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+
+deny() {
+    echo "git-branch-guard: $1" >&2
+    echo "git-branch-guard: agents must not put work on a primary branch directly." >&2
+    echo "git-branch-guard: branch first, then open a PR, e.g. 'git switch -c <branch>', push, and 'gh pr create'." >&2
+    exit 2
+}
+
+if [[ "${is_commit}" == "true" ]] && is_protected "${current_branch}"; then
+    deny "refusing to commit on primary branch '${current_branch}'"
+fi
+
+if [[ "${is_push}" == "true" ]]; then
+    push_segment=$(grep -oE "git${git_global}[[:space:]]+push[^;&|]*" <<<"${command}" | head -1 || true)
+    refspecs=${push_segment#*push}
+
+    ref_count=0
+    for tok in ${refspecs}; do
+        [[ "${tok}" == -* ]] && continue
+        ref_count=$((ref_count + 1))
+        dst=${tok##*:}
+        dst=${dst#+}
+        if [[ "${dst}" == "HEAD" ]]; then
+            dst="${current_branch}"
+        fi
+        if is_protected "${dst}"; then
+            deny "refusing to push to primary branch '${dst}'"
+        fi
+    done
+
+    # A bare push (no refspec, at most a remote) sends the current branch. Block
+    # it when that branch is primary.
+    if [[ ${ref_count} -le 1 ]] && is_protected "${current_branch}"; then
+        deny "refusing to push primary branch '${current_branch}'"
+    fi
+fi
+
+exit 0

--- a/.infra/rdev/config/managed-settings.json
+++ b/.infra/rdev/config/managed-settings.json
@@ -8,6 +8,10 @@
           {
             "type": "command",
             "command": "bash /etc/claude-code/ssh-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash /etc/claude-code/git-branch-guard.sh"
           }
         ]
       }

--- a/.infra/rdev/templates/agent-managed-settings.yaml
+++ b/.infra/rdev/templates/agent-managed-settings.yaml
@@ -8,3 +8,5 @@ data:
 {{ .Files.Get "config/managed-settings.json" | indent 4 }}
   ssh-guard.sh: |
 {{ .Files.Get "config/ssh-guard.sh" | indent 4 }}
+  git-branch-guard.sh: |
+{{ .Files.Get "config/git-branch-guard.sh" | indent 4 }}

--- a/docker/agent/git-branch-guard.sh
+++ b/docker/agent/git-branch-guard.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Claude Code. Reads the hook JSON on stdin and blocks any
+# Bash command that would commit to, or push directly to, a repository's primary
+# branch (main, master, or the remote's default). Agents must branch and open a
+# pull request. Exits 2 to block the tool call; 0 to allow it. Claude Code fires
+# PreToolUse hooks even in bypassPermissions mode.
+
+set -euo pipefail
+
+input=$(cat)
+
+tool_name=$(echo "${input}" | jq -r '.tool_name // empty')
+if [[ "${tool_name}" != "Bash" ]]; then
+    exit 0
+fi
+
+command=$(echo "${input}" | jq -r '.tool_input.command // empty')
+if [[ -z "${command}" ]]; then
+    exit 0
+fi
+
+if ! grep -qE '(^|[;&|`(]|[[:space:]])git([[:space:]]|$)' <<<"${command}"; then
+    exit 0
+fi
+
+# Match commit and push as the git subcommand, tolerating global options
+# (-C path, -c key=val, --flag[=val]) between "git" and the subcommand.
+git_global='([[:space:]]+(-C[[:space:]]+[^[:space:]]+|-c[[:space:]]+[^[:space:]]+|--[A-Za-z-]+(=[^[:space:]]+)?))*'
+is_commit=false
+is_push=false
+if grep -qE "(^|[;&|\`(]|[[:space:]])git${git_global}[[:space:]]+commit([[:space:]]|$)" <<<"${command}"; then
+    is_commit=true
+fi
+if grep -qE "(^|[;&|\`(]|[[:space:]])git${git_global}[[:space:]]+push([[:space:]]|$)" <<<"${command}"; then
+    is_push=true
+fi
+
+if [[ "${is_commit}" == "false" && "${is_push}" == "false" ]]; then
+    exit 0
+fi
+
+# Resolve the repository this command runs against: prefer an explicit
+# "git -C <path>", otherwise the tool's working directory.
+cwd=$(echo "${input}" | jq -r '.cwd // empty')
+repo_dir="${cwd:-$(pwd)}"
+if grep -qE '(^|[[:space:]])git[[:space:]]+-C[[:space:]]+[^[:space:]]+' <<<"${command}"; then
+    repo_dir=$(grep -oE '(^|[[:space:]])git[[:space:]]+-C[[:space:]]+[^[:space:]]+' <<<"${command}" | head -1 | awk '{print $NF}' || true)
+fi
+
+git_c=(git -C "${repo_dir}")
+
+protected_names="main master"
+default_branch=$("${git_c[@]}" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)
+if [[ -n "${default_branch}" ]]; then
+    protected_names="${protected_names} ${default_branch}"
+fi
+
+is_protected() {
+    local name="${1:-}" candidate
+    [[ -n "${name}" ]] || return 1
+    for candidate in ${protected_names}; do
+        [[ "${name}" == "${candidate}" ]] && return 0
+    done
+    return 1
+}
+
+current_branch=$("${git_c[@]}" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+
+deny() {
+    echo "git-branch-guard: $1" >&2
+    echo "git-branch-guard: agents must not put work on a primary branch directly." >&2
+    echo "git-branch-guard: branch first, then open a PR, e.g. 'git switch -c <branch>', push, and 'gh pr create'." >&2
+    exit 2
+}
+
+if [[ "${is_commit}" == "true" ]] && is_protected "${current_branch}"; then
+    deny "refusing to commit on primary branch '${current_branch}'"
+fi
+
+if [[ "${is_push}" == "true" ]]; then
+    push_segment=$(grep -oE "git${git_global}[[:space:]]+push[^;&|]*" <<<"${command}" | head -1 || true)
+    refspecs=${push_segment#*push}
+
+    ref_count=0
+    for tok in ${refspecs}; do
+        [[ "${tok}" == -* ]] && continue
+        ref_count=$((ref_count + 1))
+        dst=${tok##*:}
+        dst=${dst#+}
+        if [[ "${dst}" == "HEAD" ]]; then
+            dst="${current_branch}"
+        fi
+        if is_protected "${dst}"; then
+            deny "refusing to push to primary branch '${dst}'"
+        fi
+    done
+
+    # A bare push (no refspec, at most a remote) sends the current branch. Block
+    # it when that branch is primary.
+    if [[ ${ref_count} -le 1 ]] && is_protected "${current_branch}"; then
+        deny "refusing to push primary branch '${current_branch}'"
+    fi
+fi
+
+exit 0

--- a/docker/agent/managed-settings.json
+++ b/docker/agent/managed-settings.json
@@ -8,6 +8,10 @@
           {
             "type": "command",
             "command": "bash /etc/claude-code/ssh-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash /etc/claude-code/git-branch-guard.sh"
           }
         ]
       }


### PR DESCRIPTION
## Problem

Nothing stops an agent from putting work straight onto a repository's main branch. Agents authenticate with a GitHub App token and run Claude in `bypassPermissions` mode, so a `git commit` on `main` followed by a `git push` succeeds with no gate. Work is meant to reach a primary branch only through a reviewed pull request.

## Solution

Add a `git-branch-guard` PreToolUse hook, shipped in the same `/etc/claude-code` managed-settings ConfigMap as the existing `ssh-guard`, and registered as a second Bash hook. It inspects each Bash command and denies two things: a `git commit` while checked out on a primary branch, and a `git push` whose destination is a primary branch. A primary branch is `main`, `master`, or whatever the remote reports as its default. When it blocks, it tells the agent to branch and open a PR.

The hook resolves the target repository from an explicit `git -C <path>` or the tool's working directory, and handles the common push forms (`origin main`, `HEAD:main`, `feature:master`, `+main`, a bare push while on a primary branch). It is written to run on the container's bash and stays quiet for every non-git and non-mutating git command.

## Impact

Agents can no longer commit to or push a primary branch from the Bash tool. Feature-branch commits and pushes are unaffected, so the normal branch-and-PR flow keeps working. This is a client-side guardrail. Server-side branch protection remains the real enforcement.

## References

- Stacked on the hook infrastructure in https://github.com/chanzuckerberg/aws-oidc/pull/1258, which introduces the managed-settings ConfigMap and `ssh-guard`. Merge that first.