### PR TITLE
feat(agent): install the czi ai-toolchain plugin by default

### DIFF
--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -3,6 +3,35 @@ set -euo pipefail
 
 log() { echo "[entrypoint] $*" >&2; }
 
+# run_as_agent runs a command as the agent user (uid 1000) with its workspace
+# home, whether the entrypoint itself is running as root (tailscale pods) or as
+# agent (everything else).
+run_as_agent() {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        runuser -u agent -- env HOME=/workspace "$@"
+    else
+        env HOME=/workspace "$@"
+    fi
+}
+
+# ensure_agent_plugins installs the shared CZI ai-toolchain plugin so every
+# agent has it by default. Claude Code's CLI does not auto-install plugins from
+# managed settings, so the install runs here. State lives on the persistent
+# workspace volume; a marker keeps this to a single install per volume.
+ensure_agent_plugins() {
+    command -v claude >/dev/null 2>&1 || return 0
+    local marker=/workspace/.claude/.ai-toolchain-installed
+    [[ -f "${marker}" ]] && return 0
+    log "installing default plugin ai-toolchain@czi-ai-toolchain"
+    run_as_agent claude plugin marketplace add chanzuckerberg/ai-toolchain >/dev/null 2>&1 || true
+    if run_as_agent claude plugin install ai-toolchain@czi-ai-toolchain >/dev/null 2>&1; then
+        run_as_agent bash -c 'mkdir -p /workspace/.claude && touch /workspace/.claude/.ai-toolchain-installed'
+        log "ai-toolchain plugin installed"
+    else
+        log "WARN: ai-toolchain plugin install failed (needs network egress and GitHub App read access to chanzuckerberg/ai-toolchain)"
+    fi
+}
+
 if [[ "$(id -u)" -eq 0 ]]; then
     : > /etc/environment
     : > /etc/profile.d/agent-env.sh
@@ -110,5 +139,7 @@ if [[ -n "${TAILSCALE_TOKEN_FILE:-}" && -f "${TAILSCALE_TOKEN_FILE}" ]]; then
 elif [[ -n "${TAILSCALE_TOKEN_FILE:-}" ]]; then
     log "WARN: TAILSCALE_TOKEN_FILE=${TAILSCALE_TOKEN_FILE} set but file not found — skipping"
 fi
+
+ensure_agent_plugins
 
 exec "$@"


### PR DESCRIPTION
## Problem

Every agent should start with the shared CZI ai-toolchain skills already available, so its skills, commands, agents and MCP servers are there without a per-session setup step. Declaring the marketplace in managed settings is not enough. On the Claude Code CLI, which is what the agent runs, an external plugin listed in `enabledPlugins` is registered but never installed, so nothing loads until someone runs `claude plugin install` by hand.

## Solution

Install the plugins from the agent entrypoint. A helper runs `claude plugin marketplace add chanzuckerberg/ai-toolchain`, then installs `czi-general@czi-ai-toolchain` and `czi-infra@czi-ai-toolchain`, as the `agent` user with its `/workspace` home, whether the entrypoint is running as root (Tailscale pods) or as the agent user. The `czi-ai-toolchain` marketplace splits its skills across those two plugins as of v1.14.0. The plugins land on the persistent workspace volume and survive restarts. A marker file keeps this to a single install per volume, written only when both plugins install, and a failed install is logged and skipped rather than blocking startup.

## Impact

New agent pods come up with the ai-toolchain skills installed and active for the `agent` user, after Claude Code loads them on the next session start or `/reload-plugins`. Two things to know. The install needs network egress at startup and the agent's GitHub App must have read access to the internal `chanzuckerberg/ai-toolchain` repo, or the step logs a warning and moves on. The managed settings keep `allowManagedHooksOnly: true`, so the plugins' own hooks stay gated to the managed set while their skills, commands, agents and MCP servers load normally.

## References

- Plugin marketplace: https://github.com/chanzuckerberg/ai-toolchain
- Stacked on https://github.com/chanzuckerberg/aws-oidc/pull/1258, which adds the agent entrypoint and image. Merge that first.
- CLI does not auto-install managed-settings plugins: https://github.com/anthropics/claude-code/issues/45323