### PR TITLE
feat(agents): add managed CLAUDE.md steering agents to the gh CLI

### DIFF
--- a/.infra/prod/config/CLAUDE.md
+++ b/.infra/prod/config/CLAUDE.md
@@ -19,6 +19,17 @@ where a raw `git` remote call or a hand-built API request fails.
 `git diff`, and `git push` to publish a branch. Never commit or push to a repository's primary
 branch. Open a pull request with `gh pr create` instead.
 
+## Prefer git worktrees
+
+Several sessions share this pod and its `/workspace` volume at the same time. Switching
+branches in one checkout changes it for every session, so give each task its own working tree
+rather than switching branches in place.
+
+- List existing worktrees before you start: `git -C /workspace/<repo> worktree list`.
+- Create a worktree for a task: `git -C /workspace/<repo> worktree add /workspace/<repo>-<branch> -b <branch>`.
+- Work in that directory, commit there, and open a pull request with `gh pr create`.
+- Remove it when the task is done: `git -C /workspace/<repo> worktree remove /workspace/<repo>-<branch>`.
+
 ## Never
 
 - Never call `https://api.github.com` with `curl` or `wget`. Use `gh api`.

--- a/.infra/prod/config/CLAUDE.md
+++ b/.infra/prod/config/CLAUDE.md
@@ -19,6 +19,14 @@ where a raw `git` remote call or a hand-built API request fails.
 `git diff`, and `git push` to publish a branch. Never commit or push to a repository's primary
 branch. Open a pull request with `gh pr create` instead.
 
+## Your workspace already has repositories
+
+`/workspace` is a persistent volume shared across this agent's sessions. The repositories the
+agent is configured with are already cloned there, one per directory at `/workspace/<repo>`,
+and authenticated. Look there first for the source you need before cloning anything yourself.
+Treat each `/workspace/<repo>` as the primary checkout and make a worktree for your task
+rather than working on its default branch.
+
 ## Prefer git worktrees
 
 Several sessions share this pod and its `/workspace` volume at the same time. Switching

--- a/.infra/prod/config/CLAUDE.md
+++ b/.infra/prod/config/CLAUDE.md
@@ -1,0 +1,25 @@
+# GitHub access
+
+Use the `gh` CLI for every interaction with GitHub. `gh` carries this agent's GitHub App
+credentials and routes each organization to the correct App installation, so it succeeds
+where a raw `git` remote call or a hand-built API request fails.
+
+## Use `gh` for anything that talks to GitHub
+
+- Clone a repository: `gh repo clone <owner>/<repo>`.
+- Pull requests: `gh pr create`, `gh pr view`, `gh pr diff`, `gh pr checkout`, `gh pr review`, `gh pr merge`.
+- Issues: `gh issue create`, `gh issue view`, `gh issue list`.
+- CI and workflow status: `gh pr checks`, `gh run view`, `gh run list`.
+- Any GitHub REST or GraphQL call, including reading a file without cloning: `gh api ...`.
+
+## Use `git` only for local version control
+
+`gh` has no equivalent for local history, so keep using `git` for work inside a checkout:
+`git status`, `git add`, `git commit`, `git switch` and `git branch`, `git rebase`, `git log`,
+`git diff`, and `git push` to publish a branch. Never commit or push to a repository's primary
+branch. Open a pull request with `gh pr create` instead.
+
+## Never
+
+- Never call `https://api.github.com` with `curl` or `wget`. Use `gh api`.
+- Never add or change git remotes, tokens or credential helpers. Authentication is already set up.

--- a/.infra/prod/templates/agent-managed-settings.yaml
+++ b/.infra/prod/templates/agent-managed-settings.yaml
@@ -4,6 +4,8 @@ metadata:
   name: agent-managed-settings
   namespace: {{ .Release.Namespace }}
 data:
+  CLAUDE.md: |
+{{ .Files.Get "config/CLAUDE.md" | indent 4 }}
   managed-settings.json: |
 {{ .Files.Get "config/managed-settings.json" | indent 4 }}
   ssh-guard.sh: |

--- a/.infra/rdev/config/CLAUDE.md
+++ b/.infra/rdev/config/CLAUDE.md
@@ -19,6 +19,17 @@ where a raw `git` remote call or a hand-built API request fails.
 `git diff`, and `git push` to publish a branch. Never commit or push to a repository's primary
 branch. Open a pull request with `gh pr create` instead.
 
+## Prefer git worktrees
+
+Several sessions share this pod and its `/workspace` volume at the same time. Switching
+branches in one checkout changes it for every session, so give each task its own working tree
+rather than switching branches in place.
+
+- List existing worktrees before you start: `git -C /workspace/<repo> worktree list`.
+- Create a worktree for a task: `git -C /workspace/<repo> worktree add /workspace/<repo>-<branch> -b <branch>`.
+- Work in that directory, commit there, and open a pull request with `gh pr create`.
+- Remove it when the task is done: `git -C /workspace/<repo> worktree remove /workspace/<repo>-<branch>`.
+
 ## Never
 
 - Never call `https://api.github.com` with `curl` or `wget`. Use `gh api`.

--- a/.infra/rdev/config/CLAUDE.md
+++ b/.infra/rdev/config/CLAUDE.md
@@ -19,6 +19,14 @@ where a raw `git` remote call or a hand-built API request fails.
 `git diff`, and `git push` to publish a branch. Never commit or push to a repository's primary
 branch. Open a pull request with `gh pr create` instead.
 
+## Your workspace already has repositories
+
+`/workspace` is a persistent volume shared across this agent's sessions. The repositories the
+agent is configured with are already cloned there, one per directory at `/workspace/<repo>`,
+and authenticated. Look there first for the source you need before cloning anything yourself.
+Treat each `/workspace/<repo>` as the primary checkout and make a worktree for your task
+rather than working on its default branch.
+
 ## Prefer git worktrees
 
 Several sessions share this pod and its `/workspace` volume at the same time. Switching

--- a/.infra/rdev/config/CLAUDE.md
+++ b/.infra/rdev/config/CLAUDE.md
@@ -1,0 +1,25 @@
+# GitHub access
+
+Use the `gh` CLI for every interaction with GitHub. `gh` carries this agent's GitHub App
+credentials and routes each organization to the correct App installation, so it succeeds
+where a raw `git` remote call or a hand-built API request fails.
+
+## Use `gh` for anything that talks to GitHub
+
+- Clone a repository: `gh repo clone <owner>/<repo>`.
+- Pull requests: `gh pr create`, `gh pr view`, `gh pr diff`, `gh pr checkout`, `gh pr review`, `gh pr merge`.
+- Issues: `gh issue create`, `gh issue view`, `gh issue list`.
+- CI and workflow status: `gh pr checks`, `gh run view`, `gh run list`.
+- Any GitHub REST or GraphQL call, including reading a file without cloning: `gh api ...`.
+
+## Use `git` only for local version control
+
+`gh` has no equivalent for local history, so keep using `git` for work inside a checkout:
+`git status`, `git add`, `git commit`, `git switch` and `git branch`, `git rebase`, `git log`,
+`git diff`, and `git push` to publish a branch. Never commit or push to a repository's primary
+branch. Open a pull request with `gh pr create` instead.
+
+## Never
+
+- Never call `https://api.github.com` with `curl` or `wget`. Use `gh api`.
+- Never add or change git remotes, tokens or credential helpers. Authentication is already set up.

--- a/.infra/rdev/templates/agent-managed-settings.yaml
+++ b/.infra/rdev/templates/agent-managed-settings.yaml
@@ -4,6 +4,8 @@ metadata:
   name: agent-managed-settings
   namespace: {{ .Release.Namespace }}
 data:
+  CLAUDE.md: |
+{{ .Files.Get "config/CLAUDE.md" | indent 4 }}
   managed-settings.json: |
 {{ .Files.Get "config/managed-settings.json" | indent 4 }}
   ssh-guard.sh: |

--- a/.infra/rdev/templates/crd.yaml
+++ b/.infra/rdev/templates/crd.yaml
@@ -121,6 +121,23 @@ spec:
                 description: OwnerEmail is the owner's email, kept for display and
                   audit.
                 type: string
+              repositories:
+                description: |-
+                  Repositories is the set of GitHub repositories, each "owner/repo", to clone into
+                  /workspace when a thread pod boots, so sessions find the source already checked out.
+                  Clones are idempotent: a repository already present is left as is. Only meaningful when
+                  Runtime is set, since it is the thread pods that clone.
+                items:
+                  description: |-
+                    Repository is a GitHub repository in "owner/repo" form that the agent clones into its
+                    workspace at boot. The portal validates each entry is reachable by the agent's GitHub App
+                    installations before saving; the pattern here is a second line of defense for writes that
+                    bypass the portal, and keeps the value safe to hand to a shell as a single argument.
+                  maxLength: 128
+                  pattern: ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
               runtime:
                 description: |-
                   Runtime describes how the agent runs in the cluster. When unset the agent has no pods

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -96,6 +96,16 @@ stack:
           value: ""
         # To impersonate a specific user for testing, set PORTAL_DEV_SUB (and PORTAL_DEV_EMAIL)
         # to their Okta user id; that bypasses the gateway token and grants admin.
+        # The shared GitHub App powers the Repositories page: the portal searches and validates
+        # the repositories an agent may clone against what these installations can reach. Same
+        # ids as the operator below. The private key is not here: set GITHUB_APP_PRIVATE_KEY on
+        # this service with `argus set secret`, and the page stays hidden until it is.
+        - name: GITHUB_APP_ID
+          value: "4783816"
+        - name: GITHUB_APP_INSTALLATION_ID
+          value: "158028824"
+        - name: GITHUB_APP_INSTALLATION_MAP
+          value: "evolutionaryscale=158867890"
     # The agent-registry operator. Watches Agent CRs and provisions per-agent IAM roles by
     # assuming each target account's agent-provisioner role. Its ServiceAccount is bound
     # (via IRSA) to the operator control-plane role in core-platform-nonprod, which is

--- a/api/v1/agent_types.go
+++ b/api/v1/agent_types.go
@@ -66,6 +66,14 @@ type TailscaleAccess struct {
 	SSHUser string `json:"sshUser"`
 }
 
+// Repository is a GitHub repository in "owner/repo" form that the agent clones into its
+// workspace at boot. The portal validates each entry is reachable by the agent's GitHub App
+// installations before saving; the pattern here is a second line of defense for writes that
+// bypass the portal, and keeps the value safe to hand to a shell as a single argument.
+// +kubebuilder:validation:Pattern=`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`
+// +kubebuilder:validation:MaxLength=128
+type Repository string
+
 // AgentEnvVar is a plain environment variable for an agent's containers. It deliberately has
 // no valueFrom: an agent owner must not be able to project arbitrary namespace secrets into
 // their own pod.
@@ -162,6 +170,14 @@ type AgentSpec struct {
 	// +optional
 	// +listType=atomic
 	Grants []Grant `json:"grants,omitempty"`
+
+	// Repositories is the set of GitHub repositories, each "owner/repo", to clone into
+	// /workspace when a thread pod boots, so sessions find the source already checked out.
+	// Clones are idempotent: a repository already present is left as is. Only meaningful when
+	// Runtime is set, since it is the thread pods that clone.
+	// +optional
+	// +listType=set
+	Repositories []Repository `json:"repositories,omitempty"`
 
 	// Tailscale enrolls the agent's pods in the tailnet and fixes the SSH login name to the
 	// owner's email local part. When nil the agent has no tailnet identity.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -169,6 +169,11 @@ func (in *AgentSpec) DeepCopyInto(out *AgentSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Repositories != nil {
+		in, out := &in.Repositories, &out.Repositories
+		*out = make([]Repository, len(*in))
+		copy(*out, *in)
+	}
 	if in.Tailscale != nil {
 		in, out := &in.Tailscale, &out.Tailscale
 		*out = new(TailscaleAccess)

--- a/cmd/serve-portal.go
+++ b/cmd/serve-portal.go
@@ -113,7 +113,12 @@ func servePortalRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("creating identity resolver: %w", err)
 	}
 
-	srv, err := portal.NewServer(portal.Config{
+	githubApp, err := githubAppFromEnv()
+	if err != nil {
+		return fmt.Errorf("configuring github repositories: %w", err)
+	}
+
+	cfg := portal.Config{
 		Apps:             oktaAppClient,
 		MappingsProvider: mappingsProvider,
 		Store:            store,
@@ -124,7 +129,14 @@ func servePortalRun(cmd *cobra.Command, args []string) error {
 		Limits:           limits,
 		Namespace:        namespace,
 		DefaultsLoader:   agentdefaults.NewLoader(defaultsConfigPath),
-	})
+	}
+	// Assign only when configured: a nil *GitHubApp stored in the interface field would read
+	// as non-nil and turn the Repositories page on without a working backend.
+	if githubApp != nil {
+		cfg.Repositories = githubApp
+	}
+
+	srv, err := portal.NewServer(cfg)
 	if err != nil {
 		return fmt.Errorf("creating portal server: %w", err)
 	}
@@ -137,8 +149,43 @@ func servePortalRun(cmd *cobra.Command, args []string) error {
 		"rolemap_configmap", rolemapName,
 		"agent_runtime", agentRuntime,
 		"agent_tailscale", agentTailscale,
+		"agent_repositories", githubApp != nil,
 	)
 	return http.ListenAndServe(addr, srv.Handler())
+}
+
+// githubAppFromEnv builds the GitHub App client the Repositories page uses to search and
+// validate repositories. It reads the same credentials the operator uses: the app id, the
+// default installation, the owner-to-installation map, and the private key (inline in
+// GITHUB_APP_PRIVATE_KEY or a path in GITHUB_APP_PRIVATE_KEY_FILE). Returns nil when the app
+// id or key is absent, which leaves the Repositories page hidden.
+func githubAppFromEnv() (*portal.GitHubApp, error) {
+	key, err := githubAppPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+	return portal.NewGitHubApp(
+		os.Getenv("GITHUB_APP_ID"),
+		key,
+		os.Getenv("GITHUB_APP_INSTALLATION_ID"),
+		os.Getenv("GITHUB_APP_INSTALLATION_MAP"),
+		os.Getenv("GITHUB_API_URL"),
+	)
+}
+
+func githubAppPrivateKey() ([]byte, error) {
+	if pem := os.Getenv("GITHUB_APP_PRIVATE_KEY"); pem != "" {
+		return []byte(pem), nil
+	}
+	path := os.Getenv("GITHUB_APP_PRIVATE_KEY_FILE")
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading github app private key file: %w", err)
+	}
+	return data, nil
 }
 
 // agentLimits reads the ceilings an agent owner is held to when sizing their threads.

--- a/config/crd/agents.czi.team_agents.yaml
+++ b/config/crd/agents.czi.team_agents.yaml
@@ -121,6 +121,23 @@ spec:
                 description: OwnerEmail is the owner's email, kept for display and
                   audit.
                 type: string
+              repositories:
+                description: |-
+                  Repositories is the set of GitHub repositories, each "owner/repo", to clone into
+                  /workspace when a thread pod boots, so sessions find the source already checked out.
+                  Clones are idempotent: a repository already present is left as is. Only meaningful when
+                  Runtime is set, since it is the thread pods that clone.
+                items:
+                  description: |-
+                    Repository is a GitHub repository in "owner/repo" form that the agent clones into its
+                    workspace at boot. The portal validates each entry is reachable by the agent's GitHub App
+                    installations before saving; the pattern here is a second line of defense for writes that
+                    bypass the portal, and keeps the value safe to hand to a shell as a single argument.
+                  maxLength: 128
+                  pattern: ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
               runtime:
                 description: |-
                   Runtime describes how the agent runs in the cluster. When unset the agent has no pods

--- a/docker/agent/CLAUDE.md
+++ b/docker/agent/CLAUDE.md
@@ -19,6 +19,17 @@ where a raw `git` remote call or a hand-built API request fails.
 `git diff`, and `git push` to publish a branch. Never commit or push to a repository's primary
 branch. Open a pull request with `gh pr create` instead.
 
+## Prefer git worktrees
+
+Several sessions share this pod and its `/workspace` volume at the same time. Switching
+branches in one checkout changes it for every session, so give each task its own working tree
+rather than switching branches in place.
+
+- List existing worktrees before you start: `git -C /workspace/<repo> worktree list`.
+- Create a worktree for a task: `git -C /workspace/<repo> worktree add /workspace/<repo>-<branch> -b <branch>`.
+- Work in that directory, commit there, and open a pull request with `gh pr create`.
+- Remove it when the task is done: `git -C /workspace/<repo> worktree remove /workspace/<repo>-<branch>`.
+
 ## Never
 
 - Never call `https://api.github.com` with `curl` or `wget`. Use `gh api`.

--- a/docker/agent/CLAUDE.md
+++ b/docker/agent/CLAUDE.md
@@ -19,6 +19,14 @@ where a raw `git` remote call or a hand-built API request fails.
 `git diff`, and `git push` to publish a branch. Never commit or push to a repository's primary
 branch. Open a pull request with `gh pr create` instead.
 
+## Your workspace already has repositories
+
+`/workspace` is a persistent volume shared across this agent's sessions. The repositories the
+agent is configured with are already cloned there, one per directory at `/workspace/<repo>`,
+and authenticated. Look there first for the source you need before cloning anything yourself.
+Treat each `/workspace/<repo>` as the primary checkout and make a worktree for your task
+rather than working on its default branch.
+
 ## Prefer git worktrees
 
 Several sessions share this pod and its `/workspace` volume at the same time. Switching

--- a/docker/agent/CLAUDE.md
+++ b/docker/agent/CLAUDE.md
@@ -1,0 +1,25 @@
+# GitHub access
+
+Use the `gh` CLI for every interaction with GitHub. `gh` carries this agent's GitHub App
+credentials and routes each organization to the correct App installation, so it succeeds
+where a raw `git` remote call or a hand-built API request fails.
+
+## Use `gh` for anything that talks to GitHub
+
+- Clone a repository: `gh repo clone <owner>/<repo>`.
+- Pull requests: `gh pr create`, `gh pr view`, `gh pr diff`, `gh pr checkout`, `gh pr review`, `gh pr merge`.
+- Issues: `gh issue create`, `gh issue view`, `gh issue list`.
+- CI and workflow status: `gh pr checks`, `gh run view`, `gh run list`.
+- Any GitHub REST or GraphQL call, including reading a file without cloning: `gh api ...`.
+
+## Use `git` only for local version control
+
+`gh` has no equivalent for local history, so keep using `git` for work inside a checkout:
+`git status`, `git add`, `git commit`, `git switch` and `git branch`, `git rebase`, `git log`,
+`git diff`, and `git push` to publish a branch. Never commit or push to a repository's primary
+branch. Open a pull request with `gh pr create` instead.
+
+## Never
+
+- Never call `https://api.github.com` with `curl` or `wget`. Use `gh api`.
+- Never add or change git remotes, tokens or credential helpers. Authentication is already set up.

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -14,6 +14,34 @@ run_as_agent() {
     fi
 }
 
+# ensure_agent_repositories clones the repositories in AGENT_REPOSITORIES into /workspace so
+# sessions find the source already checked out. It is idempotent: a repository whose checkout
+# already exists is left untouched, which is what happens after the first session on a
+# persistent workspace. A clone that fails logs a warning and never stops the agent booting.
+ensure_agent_repositories() {
+    [[ -n "${AGENT_REPOSITORIES:-}" ]] || return 0
+    command -v gh >/dev/null 2>&1 || { log "WARN: gh not found; skipping repository clones"; return 0; }
+    local spec repo dest
+    for spec in ${AGENT_REPOSITORIES}; do
+        if [[ ! "${spec}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            log "WARN: ignoring malformed repository '${spec}' (want owner/repo)"
+            continue
+        fi
+        repo="${spec##*/}"
+        dest="/workspace/${repo}"
+        if [[ -e "${dest}/.git" ]]; then
+            log "repository ${spec} already present at ${dest}"
+            continue
+        fi
+        log "cloning ${spec} into ${dest}"
+        if run_as_agent gh repo clone "${spec}" "${dest}" >/dev/null 2>&1; then
+            log "cloned ${spec}"
+        else
+            log "WARN: failed to clone ${spec} (needs network egress and GitHub App access)"
+        fi
+    done
+}
+
 # ensure_agent_plugins installs the shared CZI ai-toolchain plugin so every
 # agent has it by default. Claude Code's CLI does not auto-install plugins from
 # managed settings, so the install runs here. State lives on the persistent
@@ -140,6 +168,7 @@ elif [[ -n "${TAILSCALE_TOKEN_FILE:-}" ]]; then
     log "WARN: TAILSCALE_TOKEN_FILE=${TAILSCALE_TOKEN_FILE} set but file not found — skipping"
 fi
 
+ensure_agent_repositories
 ensure_agent_plugins
 
 exec "$@"

--- a/internal/agentpod/agentpod_test.go
+++ b/internal/agentpod/agentpod_test.go
@@ -621,3 +621,38 @@ func TestReconcileReportsRunningThread(t *testing.T) {
 	require.Equal(t, agentsv1.ThreadStateRunning, statuses[0].State)
 	require.Equal(t, int32(1), statuses[0].ReadyReplicas)
 }
+
+// Repositories in the spec reach the thread pod as a space-separated AGENT_REPOSITORIES, which
+// the entrypoint clones into /workspace. It is absent when the spec lists none, so a pod
+// without configured repositories gets no clone step.
+func TestReconcileRepositoriesEnv(t *testing.T) {
+	ctx := context.Background()
+
+	agent := testAgent()
+	r, c := testReconciler(t, agent)
+	_, err := r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+	set := &appsv1.StatefulSet{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "agent-bot-main"}, set))
+	_, present := repoEnvValue(set)
+	require.False(t, present, "no AGENT_REPOSITORIES when the spec lists no repositories")
+
+	agent = testAgent()
+	agent.Spec.Repositories = []agentsv1.Repository{"chanzuckerberg/aws-oidc", "evolutionaryscale/foo"}
+	r, c = testReconciler(t, agent)
+	_, err = r.Reconcile(ctx, agent)
+	require.NoError(t, err)
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "agent-bot-main"}, set))
+	value, present := repoEnvValue(set)
+	require.True(t, present)
+	require.Equal(t, "chanzuckerberg/aws-oidc evolutionaryscale/foo", value)
+}
+
+func repoEnvValue(set *appsv1.StatefulSet) (string, bool) {
+	for _, e := range set.Spec.Template.Spec.Containers[0].Env {
+		if e.Name == "AGENT_REPOSITORIES" {
+			return e.Value, true
+		}
+	}
+	return "", false
+}

--- a/internal/agentpod/statefulset.go
+++ b/internal/agentpod/statefulset.go
@@ -357,6 +357,13 @@ func (r *Reconciler) env(agent *agentsv1.Agent, thread agentsv1.AgentThread) []c
 			corev1.EnvVar{Name: "GIT_COMMITTER_EMAIL", Value: agent.Spec.OwnerEmail},
 		)
 	}
+	if len(agent.Spec.Repositories) > 0 {
+		repos := make([]string, len(agent.Spec.Repositories))
+		for i, repo := range agent.Spec.Repositories {
+			repos[i] = string(repo)
+		}
+		env = append(env, corev1.EnvVar{Name: "AGENT_REPOSITORIES", Value: strings.Join(repos, " ")})
+	}
 	if r.anthropicWIFConfigured() {
 		env = append(env,
 			corev1.EnvVar{Name: "ANTHROPIC_IDENTITY_TOKEN_FILE", Value: anthropicTokenFilePath},

--- a/internal/portal/github.go
+++ b/internal/portal/github.go
@@ -1,0 +1,307 @@
+package portal
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	githubDefaultAPI    = "https://api.github.com"
+	githubReposCacheTTL = 5 * time.Minute
+)
+
+// repoSuggester suggests and validates the repositories an agent may clone. The GitHub App
+// client implements it; the Config field is left nil where the portal has no GitHub
+// credentials, which hides the Repositories tab rather than offering a search that cannot work.
+type repoSuggester interface {
+	// Suggest returns up to limit repositories whose "owner/repo" contains query, drawn from
+	// the installations the fleet's GitHub App can reach.
+	Suggest(ctx context.Context, query string, limit int) ([]string, error)
+	// Reachable reports whether repo ("owner/repo") is accessible to one of those installations.
+	Reachable(ctx context.Context, repo string) (bool, error)
+}
+
+var _ repoSuggester = (*GitHubApp)(nil)
+
+// GitHubApp lists and validates the repositories the shared GitHub App can reach across every
+// installation the fleet routes to (the default installation plus the ones in the operator's
+// installation map). The portal uses it to power the Repositories tab's type-ahead and to
+// reject repositories a thread pod could not actually clone. It caches the accessible set so a
+// burst of keystrokes does not hammer the GitHub API.
+type GitHubApp struct {
+	appID         string
+	key           *rsa.PrivateKey
+	apiURL        string
+	installations []string
+	httpClient    *http.Client
+	cacheTTL      time.Duration
+
+	mu        sync.Mutex
+	tokens    map[string]cachedToken
+	repos     []string
+	reposByID map[string]bool
+	fetchedAt time.Time
+}
+
+type cachedToken struct {
+	token  string
+	expiry time.Time
+}
+
+// NewGitHubApp builds a client for the shared App. privateKeyPEM is the App's PEM-encoded RSA
+// key. defaultInstallation is the installation every owner falls back to; installationMap is
+// the operator's "owner=id,owner2=id2" routing, whose ids are added to the reachable set.
+// Returns nil, nil when appID or the key is absent, so callers can treat missing credentials
+// as "feature off" without special-casing.
+func NewGitHubApp(appID string, privateKeyPEM []byte, defaultInstallation, installationMap, apiURL string) (*GitHubApp, error) {
+	if strings.TrimSpace(appID) == "" || len(privateKeyPEM) == 0 {
+		return nil, nil
+	}
+	key, err := parseRSAPrivateKey(privateKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parsing github app private key: %w", err)
+	}
+	if apiURL == "" {
+		apiURL = githubDefaultAPI
+	}
+	seen := map[string]bool{}
+	var installations []string
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		installations = append(installations, id)
+	}
+	add(defaultInstallation)
+	for _, entry := range strings.FieldsFunc(installationMap, func(r rune) bool { return r == ',' || r == ' ' }) {
+		_, id, ok := strings.Cut(entry, "=")
+		if ok {
+			add(id)
+		}
+	}
+	if len(installations) == 0 {
+		return nil, fmt.Errorf("github app has no installations: set a default installation id")
+	}
+	return &GitHubApp{
+		appID:         appID,
+		key:           key,
+		apiURL:        strings.TrimRight(apiURL, "/"),
+		installations: installations,
+		httpClient:    &http.Client{Timeout: 15 * time.Second},
+		cacheTTL:      githubReposCacheTTL,
+		tokens:        map[string]cachedToken{},
+	}, nil
+}
+
+func parseRSAPrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("key is neither PKCS1 nor PKCS8: %w", err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("key is not RSA")
+	}
+	return key, nil
+}
+
+func (g *GitHubApp) Suggest(ctx context.Context, query string, limit int) ([]string, error) {
+	all, _, err := g.accessible(ctx)
+	if err != nil {
+		return nil, err
+	}
+	q := strings.ToLower(strings.TrimSpace(query))
+	out := make([]string, 0, limit)
+	for _, repo := range all {
+		if q == "" || strings.Contains(strings.ToLower(repo), q) {
+			out = append(out, repo)
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (g *GitHubApp) Reachable(ctx context.Context, repo string) (bool, error) {
+	_, byID, err := g.accessible(ctx)
+	if err != nil {
+		return false, err
+	}
+	return byID[strings.ToLower(strings.TrimSpace(repo))], nil
+}
+
+// accessible returns the union of every installation's repositories as sorted "owner/repo"
+// strings, plus a lowercase membership set. The result is cached for cacheTTL.
+func (g *GitHubApp) accessible(ctx context.Context) ([]string, map[string]bool, error) {
+	g.mu.Lock()
+	if g.repos != nil && time.Since(g.fetchedAt) < g.cacheTTL {
+		repos, byID := g.repos, g.reposByID
+		g.mu.Unlock()
+		return repos, byID, nil
+	}
+	g.mu.Unlock()
+
+	byID := map[string]bool{}
+	var all []string
+	for _, id := range g.installations {
+		repos, err := g.listInstallationRepos(ctx, id)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, repo := range repos {
+			key := strings.ToLower(repo)
+			if !byID[key] {
+				byID[key] = true
+				all = append(all, repo)
+			}
+		}
+	}
+	sort.Strings(all)
+
+	g.mu.Lock()
+	g.repos, g.reposByID, g.fetchedAt = all, byID, time.Now()
+	g.mu.Unlock()
+	return all, byID, nil
+}
+
+func (g *GitHubApp) listInstallationRepos(ctx context.Context, installationID string) ([]string, error) {
+	token, err := g.installationToken(ctx, installationID)
+	if err != nil {
+		return nil, err
+	}
+	var repos []string
+	for page := 1; page <= 100; page++ {
+		u := fmt.Sprintf("%s/installation/repositories?per_page=100&page=%d", g.apiURL, page)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return nil, fmt.Errorf("building repositories request: %w", err)
+		}
+		req.Header.Set("Authorization", "token "+token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		resp, err := g.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("listing installation %s repositories: %w", installationID, err)
+		}
+		names, more, err := decodeRepoPage(resp)
+		if err != nil {
+			return nil, err
+		}
+		repos = append(repos, names...)
+		if !more {
+			break
+		}
+	}
+	return repos, nil
+}
+
+func decodeRepoPage(resp *http.Response) (repos []string, more bool, err error) {
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, false, fmt.Errorf("reading repositories response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("listing repositories: github returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out struct {
+		Repositories []struct {
+			FullName string `json:"full_name"`
+		} `json:"repositories"`
+	}
+	err = json.Unmarshal(body, &out)
+	if err != nil {
+		return nil, false, fmt.Errorf("decoding repositories response: %w", err)
+	}
+	for _, r := range out.Repositories {
+		if r.FullName != "" {
+			repos = append(repos, r.FullName)
+		}
+	}
+	return repos, len(out.Repositories) >= 100, nil
+}
+
+func (g *GitHubApp) installationToken(ctx context.Context, installationID string) (string, error) {
+	g.mu.Lock()
+	cached, ok := g.tokens[installationID]
+	g.mu.Unlock()
+	if ok && time.Until(cached.expiry) > time.Minute {
+		return cached.token, nil
+	}
+
+	jwt, err := g.appJWT()
+	if err != nil {
+		return "", err
+	}
+	u := fmt.Sprintf("%s/app/installations/%s/access_tokens", g.apiURL, installationID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
+	if err != nil {
+		return "", fmt.Errorf("building token request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("minting installation token: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("reading token response: %w", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("minting installation token: github returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	err = json.Unmarshal(body, &out)
+	if err != nil {
+		return "", fmt.Errorf("decoding token response: %w", err)
+	}
+
+	g.mu.Lock()
+	g.tokens[installationID] = cachedToken{token: out.Token, expiry: out.ExpiresAt}
+	g.mu.Unlock()
+	return out.Token, nil
+}
+
+func (g *GitHubApp) appJWT() (string, error) {
+	now := time.Now()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims := fmt.Sprintf(`{"iat":%d,"exp":%d,"iss":%q}`, now.Add(-60*time.Second).Unix(), now.Add(9*time.Minute).Unix(), g.appID)
+	payload := base64.RawURLEncoding.EncodeToString([]byte(claims))
+	signingInput := header + "." + payload
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, g.key, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("signing app jwt: %w", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}

--- a/internal/portal/github_test.go
+++ b/internal/portal/github_test.go
@@ -1,0 +1,88 @@
+package portal
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testAppKeyPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+}
+
+// A configured client suggests and validates against the union of every installation's
+// repositories, matches case-insensitively, and caches the set so a burst of keystrokes mints
+// each installation token only once.
+func TestGitHubAppSuggestAndReachable(t *testing.T) {
+	ctx := context.Background()
+
+	reposByToken := map[string][]string{
+		"tok-111": {"chanzuckerberg/aws-oidc", "chanzuckerberg/shared-infra"},
+		"tok-222": {"evolutionaryscale/foo"},
+	}
+	var tokenCalls int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /app/installations/{id}/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenCalls, 1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      "tok-" + r.PathValue("id"),
+			"expires_at": time.Now().Add(time.Hour).UTC(),
+		})
+	})
+	mux.HandleFunc("GET /installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "token ")
+		var payload struct {
+			Repositories []map[string]string `json:"repositories"`
+		}
+		for _, full := range reposByToken[token] {
+			payload.Repositories = append(payload.Repositories, map[string]string{"full_name": full})
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	app, err := NewGitHubApp("4783816", testAppKeyPEM(t), "111", "evolutionaryscale=222", server.URL)
+	require.NoError(t, err)
+	require.NotNil(t, app)
+
+	got, err := app.Suggest(ctx, "aws", 20)
+	require.NoError(t, err)
+	require.Contains(t, got, "chanzuckerberg/aws-oidc")
+
+	got, err = app.Suggest(ctx, "foo", 20)
+	require.NoError(t, err)
+	require.Equal(t, []string{"evolutionaryscale/foo"}, got)
+
+	reachable, err := app.Reachable(ctx, "Chanzuckerberg/AWS-OIDC")
+	require.NoError(t, err)
+	require.True(t, reachable, "reachability is case-insensitive")
+
+	reachable, err = app.Reachable(ctx, "someorg/private")
+	require.NoError(t, err)
+	require.False(t, reachable)
+
+	require.Equal(t, int32(2), atomic.LoadInt32(&tokenCalls), "the accessible set is cached across calls")
+}
+
+func TestNewGitHubAppNoCredentials(t *testing.T) {
+	app, err := NewGitHubApp("", nil, "111", "", "")
+	require.NoError(t, err)
+	require.Nil(t, app, "no credentials leaves the feature off")
+}

--- a/internal/portal/server.go
+++ b/internal/portal/server.go
@@ -10,6 +10,7 @@ package portal
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"log/slog"
@@ -34,6 +35,10 @@ var templatesFS embed.FS
 
 var agentNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
+// repoRe matches an "owner/repo" reference. It mirrors the Repository pattern on the CRD so
+// the portal rejects the same shapes the API server would.
+var repoRe = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+
 // Config wires the portal's dependencies. BasePath is the URL prefix the portal is served
 // under (for example "/portal" when the gateway routes a sub-path to it); empty means root.
 type Config struct {
@@ -48,6 +53,10 @@ type Config struct {
 	// AgentTailscale offers the Tailscale page. Off unless the operator is configured for
 	// tailnet enrollment, so the nav item is not shown in environments without tailscale.
 	AgentTailscale bool
+	// Repositories powers the Repositories page's type-ahead and validates saved entries
+	// against the repositories the fleet's GitHub App can reach. Nil where the portal has no
+	// GitHub credentials, which hides the page.
+	Repositories repoSuggester
 	// Limits caps the sizing an owner may ask for. Unset fields fall back to defaults.
 	Limits AgentLimits
 	// Namespace is the Kubernetes namespace the operator and agent pods run in. It is shown
@@ -99,6 +108,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /agents/{name}/tailscale", s.handleUpdateTailscale)
 	mux.HandleFunc("GET /agents/{name}/runtime", s.handleRuntime)
 	mux.HandleFunc("POST /agents/{name}/runtime", s.handleUpdateRuntime)
+	mux.HandleFunc("GET /agents/{name}/repositories", s.handleRepositories)
+	mux.HandleFunc("POST /agents/{name}/repositories", s.handleUpdateRepositories)
+	mux.HandleFunc("GET /agents/{name}/repositories/search", s.handleRepositorySearch)
 	mux.HandleFunc("POST /agents/{name}/delete", s.handleDelete)
 	mux.HandleFunc("GET /agents/{name}/threads", s.handleThreadsView)
 	mux.HandleFunc("POST /agents/{name}/threads", s.handleSpawnThread)
@@ -176,8 +188,14 @@ type pageData struct {
 	RuntimeOffered bool
 	// TailscaleOffered mirrors Config.AgentTailscale.
 	TailscaleOffered bool
-	Runtime          runtimeForm
-	TailscaleForm    tailscaleForm
+	// RepositoriesOffered is true when the portal has GitHub credentials to power the
+	// Repositories page.
+	RepositoriesOffered bool
+	Runtime             runtimeForm
+	TailscaleForm       tailscaleForm
+	// Repositories is the agent's current (or just-submitted) "owner/repo" list, shown as
+	// chips on the Repositories page.
+	Repositories []string
 }
 
 func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
@@ -522,6 +540,147 @@ func (s *Server) handleUpdateRuntime(w http.ResponseWriter, r *http.Request) {
 	s.redirect(w, r, "/agents/"+agent.Name+"/runtime")
 }
 
+func (s *Server) handleRepositories(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.Repositories == nil {
+		http.NotFound(w, r)
+		return
+	}
+	user, ok := s.user(w, r)
+	if !ok {
+		return
+	}
+	agent, ok := s.ownedAgent(w, r, user)
+	if !ok {
+		return
+	}
+	s.render(w, "agent_repositories", pageData{
+		Title:        "Repositories — " + agent.Name,
+		User:         user,
+		Agent:        agent,
+		Nav:          "repositories",
+		Repositories: repositoriesFromAgent(agent),
+	})
+}
+
+func (s *Server) handleUpdateRepositories(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.Repositories == nil {
+		http.NotFound(w, r)
+		return
+	}
+	user, ok := s.user(w, r)
+	if !ok {
+		return
+	}
+	ctx := r.Context()
+	agent, ok := s.ownedAgent(w, r, user)
+	if !ok {
+		return
+	}
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+	repos := normalizeRepos(r.Form["repository"])
+	renderErr := func(msg string) {
+		s.render(w, "agent_repositories", pageData{
+			Title: "Repositories — " + agent.Name, User: user, Agent: agent, Nav: "repositories",
+			Repositories: repos, Error: msg,
+		})
+	}
+	for _, repo := range repos {
+		if !repoRe.MatchString(repo) {
+			renderErr(fmt.Sprintf("%q is not a valid owner/repo.", repo))
+			return
+		}
+		reachable, err := s.cfg.Repositories.Reachable(ctx, repo)
+		if err != nil {
+			s.fail(w, "checking repository access", err)
+			return
+		}
+		if !reachable {
+			renderErr(fmt.Sprintf("The agent's GitHub App cannot reach %q. Pick a repository from the suggestions.", repo))
+			return
+		}
+	}
+	agent.Spec.Repositories = toRepositories(repos)
+	err = s.cfg.Store.Upsert(ctx, agent)
+	if err != nil {
+		s.fail(w, "updating agent", err)
+		return
+	}
+	s.redirect(w, r, "/agents/"+agent.Name+"/repositories")
+}
+
+// handleRepositorySearch answers the type-ahead with a JSON array of "owner/repo" strings the
+// agent's GitHub App can reach and that match the q query.
+func (s *Server) handleRepositorySearch(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.Repositories == nil {
+		http.NotFound(w, r)
+		return
+	}
+	user, ok := s.user(w, r)
+	if !ok {
+		return
+	}
+	if _, ok := s.ownedAgent(w, r, user); !ok {
+		return
+	}
+	repos, err := s.cfg.Repositories.Suggest(r.Context(), r.URL.Query().Get("q"), 20)
+	if err != nil {
+		slog.Warn("repository suggestions failed", "error", err)
+		http.Error(w, "suggestions unavailable", http.StatusBadGateway)
+		return
+	}
+	if repos == nil {
+		repos = []string{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(w).Encode(repos)
+	if err != nil {
+		slog.Error("encoding repository suggestions", "error", err)
+	}
+}
+
+func repositoriesFromAgent(agent *agentsv1.Agent) []string {
+	repos := make([]string, 0, len(agent.Spec.Repositories))
+	for _, repo := range agent.Spec.Repositories {
+		repos = append(repos, string(repo))
+	}
+	return repos
+}
+
+// normalizeRepos trims each value, drops blanks, and removes case-insensitive duplicates while
+// keeping the submitted order.
+func normalizeRepos(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		key := strings.ToLower(v)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, v)
+	}
+	return out
+}
+
+func toRepositories(values []string) []agentsv1.Repository {
+	if len(values) == 0 {
+		return nil
+	}
+	repos := make([]agentsv1.Repository, len(values))
+	for i, v := range values {
+		repos[i] = agentsv1.Repository(v)
+	}
+	return repos
+}
+
 func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.user(w, r)
 	if !ok {
@@ -772,6 +931,7 @@ func (s *Server) render(w http.ResponseWriter, name string, data pageData) {
 	data.Namespace = s.cfg.Namespace
 	data.RuntimeOffered = s.cfg.AgentRuntime
 	data.TailscaleOffered = s.cfg.AgentTailscale
+	data.RepositoriesOffered = s.cfg.Repositories != nil
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	err := s.tmpl.ExecuteTemplate(w, name, data)
 	if err != nil {

--- a/internal/portal/server_test.go
+++ b/internal/portal/server_test.go
@@ -55,4 +55,24 @@ func TestTemplatesRender(t *testing.T) {
 	})
 	require.Equal(t, 200, rec.Code)
 	require.Contains(t, rec.Body.String(), "bot")
+
+	// Repositories page renders existing entries as chips with hidden inputs to resubmit.
+	rec = httptest.NewRecorder()
+	s.render(rec, "agent_repositories", pageData{
+		Title:               "Repositories",
+		User:                &identity.User{Sub: "s"},
+		Agent:               &agentsv1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "bot"}},
+		Nav:                 "repositories",
+		RepositoriesOffered: true,
+		Repositories:        []string{"chanzuckerberg/aws-oidc"},
+	})
+	require.Equal(t, 200, rec.Code)
+	body = rec.Body.String()
+	require.Contains(t, body, `name="repository"`)
+	require.Contains(t, body, "chanzuckerberg/aws-oidc")
+}
+
+func TestNormalizeReposDeduplicatesAndTrims(t *testing.T) {
+	got := normalizeRepos([]string{" chanzuckerberg/aws-oidc ", "", "chanzuckerberg/AWS-OIDC", "evolutionaryscale/foo"})
+	require.Equal(t, []string{"chanzuckerberg/aws-oidc", "evolutionaryscale/foo"}, got)
 }

--- a/internal/portal/templates/agent_repositories.html
+++ b/internal/portal/templates/agent_repositories.html
@@ -1,0 +1,162 @@
+{{define "agent_repositories"}}{{template "head" .}}
+<style>
+  .repo-typeahead { position: relative; max-width: 32rem; }
+  .repo-typeahead input[type=text] { width: 100%; padding: .4rem .5rem; border: 1px solid #bbb; border-radius: 5px; }
+  .repo-suggestions { position: absolute; z-index: 10; left: 0; right: 0; margin: 2px 0 0; padding: 0; list-style: none; background: #fff; border: 1px solid #bbb; border-radius: 5px; box-shadow: 0 4px 12px rgba(0,0,0,.08); max-height: 16rem; overflow-y: auto; }
+  .repo-suggestions:empty { display: none; }
+  .repo-suggestions li { padding: .4rem .6rem; cursor: pointer; font-size: .9em; }
+  .repo-suggestions li:hover, .repo-suggestions li.active { background: #f0faf4; }
+  .chips { display: flex; flex-wrap: wrap; gap: .4rem; margin: .75rem 0 0; padding: 0; }
+  .chips:empty::before { content: "No repositories yet. Start typing above to add one."; color: #999; font-size: .9em; }
+  .chip { display: inline-flex; align-items: center; gap: .35rem; background: #f0faf4; border: 1px solid #1a5; border-radius: 999px; padding: .2rem .3rem .2rem .7rem; font-size: .85em; }
+  .chip-remove { border: none; background: none; cursor: pointer; color: #1a5; font-size: 1.1em; line-height: 1; padding: 0 .2rem; }
+</style>
+<div class="page">
+  <div class="edit-layout">
+    {{template "agentnav" .}}
+    <div class="card">
+      <h1>Repositories</h1>
+      {{if .Error}}<p class="err">{{.Error}}</p>{{end}}
+      <p class="muted">
+        These repositories are cloned into <code>/workspace</code> when a thread pod boots, so
+        sessions find the source already checked out and authenticated. Start typing to search
+        the repositories this agent's GitHub App can reach, and pick from the suggestions.
+      </p>
+
+      <form id="repo-form" method="post"
+            action="{{.BasePath}}/agents/{{.Agent.Name}}/repositories"
+            data-base-path="{{.BasePath}}" data-agent="{{.Agent.Name}}">
+        <div class="repo-typeahead">
+          <input type="text" id="repo-input" autocomplete="off" spellcheck="false"
+                 placeholder="owner/repo">
+          <ul class="repo-suggestions" id="repo-suggestions"></ul>
+        </div>
+
+        <div class="chips" id="repo-chips">
+          {{range .Repositories}}
+          <span class="chip" data-repo="{{.}}">
+            <span class="chip-label">{{.}}</span>
+            <button type="button" class="chip-remove" aria-label="Remove {{.}}">&times;</button>
+            <input type="hidden" name="repository" value="{{.}}">
+          </span>
+          {{end}}
+        </div>
+
+        <p style="margin-top:1rem;">
+          <button class="btn primary" type="submit">Save</button>
+        </p>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  var form = document.getElementById("repo-form");
+  var input = document.getElementById("repo-input");
+  var suggestions = document.getElementById("repo-suggestions");
+  var chips = document.getElementById("repo-chips");
+  var basePath = form.dataset.basePath || "";
+  var agent = form.dataset.agent;
+  var repoPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+  var debounce;
+
+  function selected() {
+    var set = {};
+    chips.querySelectorAll(".chip").forEach(function (chip) {
+      set[(chip.dataset.repo || "").toLowerCase()] = true;
+    });
+    return set;
+  }
+
+  function clearSuggestions() { suggestions.innerHTML = ""; }
+
+  function addChip(repo) {
+    repo = (repo || "").trim();
+    if (!repo || selected()[repo.toLowerCase()]) { return; }
+
+    var chip = document.createElement("span");
+    chip.className = "chip";
+    chip.dataset.repo = repo;
+
+    var label = document.createElement("span");
+    label.className = "chip-label";
+    label.textContent = repo;
+
+    var remove = document.createElement("button");
+    remove.type = "button";
+    remove.className = "chip-remove";
+    remove.setAttribute("aria-label", "Remove " + repo);
+    remove.textContent = "\u00d7";
+    remove.addEventListener("click", function () { chip.remove(); });
+
+    var hidden = document.createElement("input");
+    hidden.type = "hidden";
+    hidden.name = "repository";
+    hidden.value = repo;
+
+    chip.appendChild(label);
+    chip.appendChild(remove);
+    chip.appendChild(hidden);
+    chips.appendChild(chip);
+  }
+
+  function renderSuggestions(repos) {
+    clearSuggestions();
+    var have = selected();
+    repos.forEach(function (repo) {
+      if (have[repo.toLowerCase()]) { return; }
+      var li = document.createElement("li");
+      li.textContent = repo;
+      li.addEventListener("mousedown", function (event) {
+        event.preventDefault();
+        addChip(repo);
+        input.value = "";
+        clearSuggestions();
+      });
+      suggestions.appendChild(li);
+    });
+  }
+
+  function search(query) {
+    var url = basePath + "/agents/" + encodeURIComponent(agent) +
+      "/repositories/search?q=" + encodeURIComponent(query);
+    fetch(url, { headers: { "Accept": "application/json" } })
+      .then(function (resp) { return resp.ok ? resp.json() : []; })
+      .then(renderSuggestions)
+      .catch(clearSuggestions);
+  }
+
+  input.addEventListener("input", function () {
+    var query = input.value.trim();
+    clearTimeout(debounce);
+    if (query.length < 2) { clearSuggestions(); return; }
+    debounce = setTimeout(function () { search(query); }, 150);
+  });
+
+  input.addEventListener("keydown", function (event) {
+    if (event.key !== "Enter") { return; }
+    event.preventDefault();
+    var first = suggestions.querySelector("li");
+    if (first) {
+      addChip(first.textContent);
+    } else if (repoPattern.test(input.value.trim())) {
+      addChip(input.value.trim());
+    }
+    input.value = "";
+    clearSuggestions();
+  });
+
+  document.addEventListener("click", function (event) {
+    if (!form.contains(event.target)) { clearSuggestions(); }
+  });
+
+  chips.querySelectorAll(".chip-remove").forEach(function (button) {
+    button.addEventListener("click", function () {
+      var chip = button.closest(".chip");
+      if (chip) { chip.remove(); }
+    });
+  });
+})();
+</script>
+{{template "foot" .}}{{end}}

--- a/internal/portal/templates/layout.html
+++ b/internal/portal/templates/layout.html
@@ -72,6 +72,7 @@
   <div class="sidenav-section">Configure</div>
   <a href="{{.BasePath}}/agents/{{.Agent.Name}}" {{if eq .Nav "general"}}class="active"{{end}}>General</a>
   <a href="{{.BasePath}}/agents/{{.Agent.Name}}/aws" {{if eq .Nav "aws"}}class="active"{{end}}>AWS access</a>
+  {{if .RepositoriesOffered}}<a href="{{.BasePath}}/agents/{{.Agent.Name}}/repositories" {{if eq .Nav "repositories"}}class="active"{{end}}>Repositories</a>{{end}}
   {{if .TailscaleOffered}}<a href="{{.BasePath}}/agents/{{.Agent.Name}}/tailscale" {{if eq .Nav "tailscale"}}class="active"{{end}}>Tailscale</a>{{end}}
   {{if .RuntimeOffered}}
   <a href="{{.BasePath}}/agents/{{.Agent.Name}}/runtime" {{if eq .Nav "runtime"}}class="active"{{end}}>Runtime</a>


### PR DESCRIPTION
## Problem

Agents reach for raw `git` and hand-built GitHub API calls, which fail against the App-backed auth the agent environment provides. Nothing tells an agent to prefer `gh`, which carries the GitHub App credentials and, since #1261, routes each organization to the right App installation.

## Solution

Ship an organization-wide instruction as a Claude Code managed-policy memory. A new `CLAUDE.md` joins the `agent-managed-settings` ConfigMap, so it lands at `/etc/claude-code/CLAUDE.md`, the Linux managed-policy path Claude Code loads first every session and that users cannot exclude. It tells agents to use `gh` for everything that talks to GitHub (clone, pull requests, issues, CI status, and any REST or GraphQL call through `gh api`) and to use `git` only for local version control that `gh` has no equivalent for.

The file follows the same shape as the other managed files: canonical copy in `docker/agent/`, mirrored into `.infra/rdev/config` and `.infra/prod/config` for Helm to include. No operator change is needed because the ConfigMap already mounts as a directory at `/etc/claude-code`.

## Impact

Every agent session, in rdev and prod, begins with the guidance to drive GitHub through `gh`. Behavior only, so it changes how agents choose commands, not what they are permitted to do.

## References

Stacked on #1258 (`heathj/agent-tailscale-ssh-guard`). Builds on the per-organization `gh` routing from #1261 (merged into #1258). Merge #1258 first.